### PR TITLE
Persistency for Shared Devices

### DIFF
--- a/UsbIpServer/ConnectedClient.cs
+++ b/UsbIpServer/ConnectedClient.cs
@@ -62,12 +62,12 @@ namespace UsbIpServer
             }
         }
 
-        static async Task<ExportedDevice[]> GetAvailableDevicesAsync(CancellationToken cancellationToken)
+        static async Task<ExportedDevice[]> GetSharedDevicesAsync(CancellationToken cancellationToken)
         {
             if (RegistryUtils.HasRegistryAccess())
             {
                 return (await ExportedDevice.GetAll(cancellationToken))
-               .Where(x => RegistryUtils.IsDeviceAvailable(x.BusId))
+               .Where(x => RegistryUtils.IsDeviceShared(x))
                .ToArray();
             }
 
@@ -76,7 +76,7 @@ namespace UsbIpServer
 
         async Task HandleRequestDeviceListAsync(CancellationToken cancellationToken)
         {
-            var exportedDevices = await GetAvailableDevicesAsync(cancellationToken);
+            var exportedDevices = await GetSharedDevicesAsync(cancellationToken);
 
             await SendOpCodeAsync(OpCode.OP_REP_DEVLIST, Status.ST_OK);
 
@@ -100,7 +100,7 @@ namespace UsbIpServer
 
             try
             {
-                var exportedDevices = await GetAvailableDevicesAsync(cancellationToken);
+                var exportedDevices = await GetSharedDevicesAsync(cancellationToken);
 
                 status = Status.ST_NODEV;
                 var exportedDevice = exportedDevices.Single(x => x.BusId == busid);

--- a/UsbIpServer/ConnectedClient.cs
+++ b/UsbIpServer/ConnectedClient.cs
@@ -131,6 +131,8 @@ namespace UsbIpServer
                     Watcher.WatchDevice(busid, () => attachedClientTokenSource.Cancel());
                     var attachedClientToken = attachedClientTokenSource.Token;
                     RegistryUtils.SetDeviceAsAttached(exportedDevice);
+                    var iPEndPoint = ClientContext.TcpClient.Client.RemoteEndPoint as IPEndPoint;
+                    RegistryUtils.SetDeviceAddress(exportedDevice, iPEndPoint!.Address.MapToIPv4().ToString());
                     await ServiceProvider.GetRequiredService<AttachedClient>().RunAsync(attachedClientToken);
                 }
                 finally

--- a/UsbIpServer/DeviceChecker.cs
+++ b/UsbIpServer/DeviceChecker.cs
@@ -31,8 +31,20 @@ namespace UsbIpServer
             collection.Dispose();
         }
 
-        public string GetDeviceName(string path)
+        public string GetDeviceName(ExportedDevice device)
         {
+            // first try to get name from registry
+            var registryKey = RegistryUtils.GetRegistryKey(device);
+            if (registryKey != null)
+            {
+                var name = (string?)registryKey.GetValue("Name");
+                if (name != null)
+                {
+                    return name;
+                }
+            }
+
+            var path = device.Path;
             var possibleDeviceNames = new SortedSet<string>();
             foreach (var usbDevice in devices)
             {

--- a/UsbIpServer/LogEvents.cs
+++ b/UsbIpServer/LogEvents.cs
@@ -8,5 +8,6 @@ namespace UsbIpServer
     {
         public const int ClientAttach = 1;
         public const int ClientDetach = 2;
+        public const int ClientError = 3;
     }
 }

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -127,14 +127,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         return 0;
                     }
 
-                    var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
-                    if (targetDevice != null && !RegistryUtils.IsDeviceShared(targetDevice))
+                    try
                     {
-                        var checker = new DeviceInfoChecker();
-                        RegistryUtils.ShareDevice(targetDevice, checker.GetDeviceName(targetDevice));
+                        var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
+                        if (targetDevice != null && !RegistryUtils.IsDeviceShared(targetDevice))
+                        {
+                            var checker = new DeviceInfoChecker();
+                            RegistryUtils.ShareDevice(targetDevice, checker.GetDeviceName(targetDevice));
+                        }
+
+                        return 0;
+                    } catch (InvalidOperationException)
+                    {
+                        Console.Error.WriteLine("There's no device with the specified BUS-ID.");
+                        return 1;
                     }
-                    
-                    return 0;
                 });
             });
 
@@ -156,20 +163,36 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
                     if (busId.HasValue())
                     {
-                        var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
-                        var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
-                        if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
+                        try
                         {
-                            RegistryUtils.StopSharingDevice(targetDevice);
-                        }
-                        return 0;
+                            var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
+                            var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
+                            if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
+                            {
+                                RegistryUtils.StopSharingDevice(targetDevice);
+                            }
+
+                            return 0;
+                        } catch (InvalidOperationException)
+                        {
+                            Console.Error.WriteLine("There's no device with the specified BUS-ID.");
+                            return 1;
+                        }   
                     }
 
                     if (guid.HasValue())
                     {
-                        RegistryUtils.StopSharingDevice(guid.Value());
+                        try
+                        {
+                            RegistryUtils.StopSharingDevice(guid.Value());
+                            return 0;
+                        } catch (ArgumentException)
+                        {
+                            Console.Error.WriteLine("There's no device with the specified GUID.");
+                            return 1;
+                        }
                     }
-                    
+
                     return 0;
                 });
             });

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -134,18 +134,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 DefaultCmdLine(cmd);
                 cmd.OnExecute(async () =>
                 {
+                    var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
                     if (unbindAll.HasValue())
                     {
-                        var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
-                        foreach (var id in connectedDevices.Select(x => x.BusId))
+                        
+                        foreach (var device in connectedDevices)
                         {
-                            //RegistryUtils.SetDeviceAvailability(id, false);
+                            RegistryUtils.StopSharingDevice(device);
                         }
 
                         return 0;
                     }
 
-                    //RegistryUtils.SetDeviceAvailability(busId.Value(), false);
+                    var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
+                    if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
+                    {
+                        RegistryUtils.StopSharingDevice(targetDevice);
+                    }
                     return 0;
                 });
             });

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -86,7 +86,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 DefaultCmdLine(cmd);
                 cmd.OnExecute(async () =>
                 {
-                    Console.WriteLine($"{"ID", -6}{"Device", -60}{"Available", -5}");
+                    Console.WriteLine($"{"ID", -6}{"Device", -60}{"Shared", -5}");
                     var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
                     var deviceChecker = new DeviceInfoChecker();
                     foreach (var device in connectedDevices)
@@ -118,9 +118,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                     }
 
                     var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
-                    if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
+                    if (targetDevice != null && !RegistryUtils.IsDeviceShared(targetDevice))
                     {
-                        RegistryUtils.ShareDevice(targetDevice);
+                        RegistryUtils.ShareDevice(targetDevice, description);
                     }
                     
                     return 0;

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -103,6 +103,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         Console.WriteLine($"{device.Guid,-38}{device.BusId, -8}{Truncate(device.Name, 60),-60}");
                     }
 
+                    if (!Server.IsServerRunning())
+                    {
+                        Console.WriteLine("\nWARNING: Server is currently not running.");
+                    }
+
                     return 0;
                 });
             });

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -90,7 +90,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                     var deviceChecker = new DeviceInfoChecker();
                     foreach (var device in connectedDevices)
                     {
-                        Console.WriteLine($"{device.BusId, -6}{Truncate(deviceChecker.GetDeviceName(device.Path.Replace(@"\\", @"\", StringComparison.Ordinal)), 60),-60}{ (RegistryUtils.IsDeviceAvailable(device.BusId)? "Yes": "No"), -5}");
+                        Console.WriteLine($"{device.BusId, -6}{Truncate(deviceChecker.GetDeviceName(device.Path.Replace(@"\\", @"\", StringComparison.Ordinal)), 60),-60}{ (RegistryUtils.IsDeviceShared(device)? "Yes": "No"), -5}");
                     }
 
                     return 0;
@@ -105,18 +105,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 DefaultCmdLine(cmd);
                 cmd.OnExecute(async () =>
                 {
+                    var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
                     if (bindAll.HasValue())
                     {
-                        var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
-                        foreach (var id in connectedDevices.Select(x => x.BusId))
+                        foreach (var device in connectedDevices)
                         {
-                            RegistryUtils.SetDeviceAvailability(id, true);
+                            RegistryUtils.ShareDevice(device);
                         }
 
                         return 0;
                     }
 
-                    RegistryUtils.SetDeviceAvailability(busId.Value(), true);
+                    var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
+                    if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
+                    {
+                        RegistryUtils.ShareDevice(targetDevice);
+                    }
+                    
                     return 0;
                 });
             });
@@ -134,13 +139,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
                         foreach (var id in connectedDevices.Select(x => x.BusId))
                         {
-                            RegistryUtils.SetDeviceAvailability(id, false);
+                            //RegistryUtils.SetDeviceAvailability(id, false);
                         }
 
                         return 0;
                     }
 
-                    RegistryUtils.SetDeviceAvailability(busId.Value(), false);
+                    //RegistryUtils.SetDeviceAvailability(busId.Value(), false);
                     return 0;
                 });
             });

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -71,7 +71,7 @@ namespace UsbIpServer
 
         // To share is to equivalently have it in the registry.
         // If a device is not in the registry, then it is not shared.
-        public static void ShareDevice(ExportedDevice device)
+        public static void ShareDevice(ExportedDevice device, string name)
         {
             var guid = Guid.NewGuid();
             var entry = Registry.LocalMachine.CreateSubKey(@$"{DevicesRegistryPath}\{guid}");

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -17,17 +17,84 @@ namespace UsbIpServer
 
         static class DeviceFilter
         {
-            return Registry.LocalMachine.OpenSubKey(DevicesRegistryPath)?.GetSubKeyNames().Any(x => x == busId) ?? false;
+            public const string VENDOR_ID = "VendorId";
+            public const string PRODUCT_ID = "ProductId";
+            public const string BCD_DEVICE = "BcdDevice";
+            public const string DEVICE_CLASS = "DeviceClass";
+            public const string DEVICE_SUBCLASS = "DeviceSubClass";
+            public const string DEVICE_PROTOCOL = "DeviceProtocol";
+            public const string DEV_NUM = "DevNum";
+            public const string BUS_ID = "BusId";
         }
 
         public static bool IsDeviceShared(ExportedDevice device)
         {
-            if (enable)
-            { 
-                Registry.LocalMachine.CreateSubKey($@"{DevicesRegistryPath}\{busId}");
-            } else if (IsDeviceAvailable(busId))
+            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
+            foreach (var keyName in deviceKeyNames)
             {
-                Registry.LocalMachine.DeleteSubKey($@"{DevicesRegistryPath}\{busId}");
+                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
+                if (IsDeviceMatchInRegistry(deviceKey, device))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool IsDeviceMatchInRegistry(RegistryKey deviceKey, ExportedDevice device)
+        {
+            try
+            {
+                var cultureInfo = new CultureInfo("en-US");
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+                if ((string)deviceKey.GetValue(DeviceFilter.VENDOR_ID) == device.VendorId.ToString(cultureInfo) |
+                    (string)deviceKey.GetValue(DeviceFilter.PRODUCT_ID) == device.ProductId.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.BCD_DEVICE) == device.BcdDevice.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEVICE_CLASS) == device.DeviceClass.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEVICE_SUBCLASS) == device.DeviceSubClass.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEVICE_PROTOCOL) == device.DeviceProtocol.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEV_NUM) == device.DevNum.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.BUS_ID) == device.BusId)
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+                {
+                    return true;
+                }
+            }
+            catch (NullReferenceException)
+            {
+                // this is expected if a value does not exist in the registry key.
+            }
+
+            return false;
+        }
+
+        // To share is to equivalently have it in the registry.
+        // If a device is not in the registry, then it is not shared.
+        public static void ShareDevice(ExportedDevice device)
+        {
+            var guid = Guid.NewGuid();
+            var entry = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{guid}");
+            entry.SetValue(DeviceFilter.VENDOR_ID, device.VendorId);
+            entry.SetValue(DeviceFilter.PRODUCT_ID, device.ProductId);
+            entry.SetValue(DeviceFilter.BCD_DEVICE, device.BcdDevice);
+            entry.SetValue(DeviceFilter.DEVICE_CLASS, device.DeviceClass);
+            entry.SetValue(DeviceFilter.DEVICE_SUBCLASS, device.DeviceSubClass);
+            entry.SetValue(DeviceFilter.DEVICE_PROTOCOL, device.DeviceProtocol);
+            entry.SetValue(DeviceFilter.DEV_NUM, device.DevNum);
+            entry.SetValue(DeviceFilter.BUS_ID, device.BusId);
+        }
+
+        public static void StopSharingDevice(ExportedDevice device)
+        {
+            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
+            foreach (var keyName in deviceKeyNames)
+            {
+                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
+                if (IsDeviceMatchInRegistry(deviceKey, device))
+                {
+                    Registry.LocalMachine.DeleteSubKeyTree(@$"{devicesRegistryPath}\{keyName}");
+                }               
             }
         }
 

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -37,7 +37,7 @@ namespace UsbIpServer
             var key = GetRegistryKey(device);
             if (key != null)
             {
-                return key.GetSubKeyNames().Contains("Attached");
+                return key.GetSubKeyNames().Contains("Attached") && Server.IsServerRunning();
             }
 
             return false;

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using Microsoft.Win32;
 using System.Security.Principal;
+using System;
 
 namespace UsbIpServer
 {
@@ -12,20 +13,67 @@ namespace UsbIpServer
     {
         const string devicesRegistryPath = @"SOFTWARE\USBIPD-WIN";
 
-        public static bool IsDeviceAvailable(string busId)
+        public static bool IsDeviceShared(ExportedDevice device)
         {
-            return Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames().Any(x => x == busId);
+            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
+            foreach (var keyName in deviceKeyNames)
+            {
+                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
+                try
+                {
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+                    if ((string) deviceKey.GetValue(Filter.VENDOR_ID) != device.VendorId.ToString() |
+                    (string) deviceKey.GetValue(Filter.PRODUCT_ID) != device.ProductId.ToString() ||
+                    (string) deviceKey.GetValue(Filter.BCD_DEVICE) != device.BcdDevice.ToString() ||
+                    (string) deviceKey.GetValue(Filter.DEVICE_CLASS) != device.DeviceClass.ToString() ||
+                    (string) deviceKey.GetValue(Filter.DEVICE_SUBCLASS) != device.DeviceSubClass.ToString() ||
+                    (string) deviceKey.GetValue(Filter.DEVICE_PROTOCOL) != device.DeviceProtocol.ToString() ||
+                    (string) deviceKey.GetValue(Filter.DEV_NUM) != device.DevNum.ToString() ||
+                    (string)deviceKey.GetValue(Filter.BUS_ID) != device.BusId)
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+                    {
+                        continue;
+                    }
+                }
+                catch (NullReferenceException)
+                {
+                    // this is expected if a value does not exist in the registry key.
+                    continue;
+                }
+                
+
+                return true;
+            }
+
+            return false;
         }
 
-        public static void SetDeviceAvailability(string busId, bool enable)
+        static class Filter
         {
-            if (enable)
-            { 
-                Registry.LocalMachine.CreateSubKey($@"{devicesRegistryPath}\{busId}");
-            } else if (IsDeviceAvailable(busId))
-            {
-                Registry.LocalMachine.DeleteSubKey($@"{devicesRegistryPath}\{busId}");
-            }
+            public const string VENDOR_ID = "VendorId";
+            public const string PRODUCT_ID = "ProductId";
+            public const string BCD_DEVICE = "BcdDevice";
+            public const string DEVICE_CLASS = "DeviceClass";
+            public const string DEVICE_SUBCLASS = "DeviceSubClass";
+            public const string DEVICE_PROTOCOL = "DeviceProtocol";
+            public const string DEV_NUM = "DevNum";
+            public const string BUS_ID = "BusId";
+        }
+
+        // To share is to equivalently have it in the registry.
+        // If a device is not in the registry, then it is not shared.
+        public static void ShareDevice(ExportedDevice device)
+        {
+            var guid = Guid.NewGuid();
+            var entry = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{guid}");
+            entry.SetValue(Filter.VENDOR_ID, device.VendorId);
+            entry.SetValue(Filter.PRODUCT_ID, device.ProductId);
+            entry.SetValue(Filter.BCD_DEVICE, device.BcdDevice);
+            entry.SetValue(Filter.DEVICE_CLASS, device.DeviceClass);
+            entry.SetValue(Filter.DEVICE_SUBCLASS, device.DeviceSubClass);
+            entry.SetValue(Filter.DEVICE_PROTOCOL, device.DeviceProtocol);
+            entry.SetValue(Filter.DEV_NUM, device.DevNum);
+            entry.SetValue(Filter.BUS_ID, device.BusId);
         }
 
         public static string[] GetRegistryDevices()

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -46,7 +46,7 @@ namespace UsbIpServer
         static bool IsDeviceMatch(RegistryKey deviceKey, ExportedDevice device)
         {
             
-            var cultureInfo = new CultureInfo("en-US");
+            var cultureInfo = CultureInfo.InvariantCulture;
             if ((string?)deviceKey.GetValue(DeviceFilter.VENDOR_ID) == device.VendorId.ToString(cultureInfo) &&
                 (string?)deviceKey.GetValue(DeviceFilter.PRODUCT_ID) == device.ProductId.ToString(cultureInfo) &&
                 (string?)deviceKey.GetValue(DeviceFilter.BCD_DEVICE) == device.BcdDevice.ToString(cultureInfo) &&

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -165,7 +165,16 @@ namespace UsbIpServer
                 Registry.LocalMachine.DeleteSubKeyTree(@$"{DevicesRegistryPath}\{keyName}\Attached");
             }
         }
-        
+
+        public static void SetDeviceAddress(ExportedDevice device, string address)
+        {
+            var key = GetRegistryKey(device);
+            if (key != null)
+            {
+                key.SetValue("VIP", address);
+            }
+        }
+
         public static List<PersistedDevice> GetPersistedDevices(ExportedDevice[] connectedDevices)
         {
             var persistedDevices = new List<PersistedDevice>();

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -171,7 +171,7 @@ namespace UsbIpServer
             var key = GetRegistryKey(device);
             if (key != null)
             {
-                key.SetValue("VIP", address);
+                key.SetValue("IPAddress", address);
             }
         }
 

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.Win32;
 using System.Security.Principal;
 using System;
+using System.Globalization;
 
 namespace UsbIpServer
 {
@@ -13,42 +14,7 @@ namespace UsbIpServer
     {
         const string devicesRegistryPath = @"SOFTWARE\USBIPD-WIN";
 
-        public static bool IsDeviceShared(ExportedDevice device)
-        {
-            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
-            foreach (var keyName in deviceKeyNames)
-            {
-                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
-                try
-                {
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-                    if ((string) deviceKey.GetValue(Filter.VENDOR_ID) != device.VendorId.ToString() |
-                    (string) deviceKey.GetValue(Filter.PRODUCT_ID) != device.ProductId.ToString() ||
-                    (string) deviceKey.GetValue(Filter.BCD_DEVICE) != device.BcdDevice.ToString() ||
-                    (string) deviceKey.GetValue(Filter.DEVICE_CLASS) != device.DeviceClass.ToString() ||
-                    (string) deviceKey.GetValue(Filter.DEVICE_SUBCLASS) != device.DeviceSubClass.ToString() ||
-                    (string) deviceKey.GetValue(Filter.DEVICE_PROTOCOL) != device.DeviceProtocol.ToString() ||
-                    (string) deviceKey.GetValue(Filter.DEV_NUM) != device.DevNum.ToString() ||
-                    (string)deviceKey.GetValue(Filter.BUS_ID) != device.BusId)
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-                    {
-                        continue;
-                    }
-                }
-                catch (NullReferenceException)
-                {
-                    // this is expected if a value does not exist in the registry key.
-                    continue;
-                }
-                
-
-                return true;
-            }
-
-            return false;
-        }
-
-        static class Filter
+        static class DeviceFilter
         {
             public const string VENDOR_ID = "VendorId";
             public const string PRODUCT_ID = "ProductId";
@@ -60,20 +26,75 @@ namespace UsbIpServer
             public const string BUS_ID = "BusId";
         }
 
+        public static bool IsDeviceShared(ExportedDevice device)
+        {
+            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
+            foreach (var keyName in deviceKeyNames)
+            {
+                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
+                if (IsDeviceMatchInRegistry(deviceKey, device))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool IsDeviceMatchInRegistry(RegistryKey deviceKey, ExportedDevice device)
+        {
+            try
+            {
+                var cultureInfo = new CultureInfo("en-US");
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+                if ((string)deviceKey.GetValue(DeviceFilter.VENDOR_ID) == device.VendorId.ToString(cultureInfo) |
+                    (string)deviceKey.GetValue(DeviceFilter.PRODUCT_ID) == device.ProductId.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.BCD_DEVICE) == device.BcdDevice.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEVICE_CLASS) == device.DeviceClass.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEVICE_SUBCLASS) == device.DeviceSubClass.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEVICE_PROTOCOL) == device.DeviceProtocol.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.DEV_NUM) == device.DevNum.ToString(cultureInfo) ||
+                    (string)deviceKey.GetValue(DeviceFilter.BUS_ID) == device.BusId)
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+                {
+                    return true;
+                }
+            }
+            catch (NullReferenceException)
+            {
+                // this is expected if a value does not exist in the registry key.
+            }
+
+            return false;
+        }
+
         // To share is to equivalently have it in the registry.
         // If a device is not in the registry, then it is not shared.
         public static void ShareDevice(ExportedDevice device)
         {
             var guid = Guid.NewGuid();
             var entry = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{guid}");
-            entry.SetValue(Filter.VENDOR_ID, device.VendorId);
-            entry.SetValue(Filter.PRODUCT_ID, device.ProductId);
-            entry.SetValue(Filter.BCD_DEVICE, device.BcdDevice);
-            entry.SetValue(Filter.DEVICE_CLASS, device.DeviceClass);
-            entry.SetValue(Filter.DEVICE_SUBCLASS, device.DeviceSubClass);
-            entry.SetValue(Filter.DEVICE_PROTOCOL, device.DeviceProtocol);
-            entry.SetValue(Filter.DEV_NUM, device.DevNum);
-            entry.SetValue(Filter.BUS_ID, device.BusId);
+            entry.SetValue(DeviceFilter.VENDOR_ID, device.VendorId);
+            entry.SetValue(DeviceFilter.PRODUCT_ID, device.ProductId);
+            entry.SetValue(DeviceFilter.BCD_DEVICE, device.BcdDevice);
+            entry.SetValue(DeviceFilter.DEVICE_CLASS, device.DeviceClass);
+            entry.SetValue(DeviceFilter.DEVICE_SUBCLASS, device.DeviceSubClass);
+            entry.SetValue(DeviceFilter.DEVICE_PROTOCOL, device.DeviceProtocol);
+            entry.SetValue(DeviceFilter.DEV_NUM, device.DevNum);
+            entry.SetValue(DeviceFilter.BUS_ID, device.BusId);
+        }
+
+        public static void StopSharingDevice(ExportedDevice device)
+        {
+            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
+            foreach (var keyName in deviceKeyNames)
+            {
+                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
+                if (IsDeviceMatchInRegistry(deviceKey, device))
+                {
+                    Registry.LocalMachine.DeleteSubKeyTree(@$"{devicesRegistryPath}\{keyName}");
+                }               
+            }
         }
 
         public static string[] GetRegistryDevices()

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -29,10 +29,10 @@ namespace UsbIpServer
 
         public static bool IsDeviceShared(ExportedDevice device)
         {
-            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
+            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(DevicesRegistryPath).GetSubKeyNames();
             foreach (var keyName in deviceKeyNames)
             {
-                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
+                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{DevicesRegistryPath}\{keyName}");
                 if (IsDeviceMatchInRegistry(deviceKey, device))
                 {
                     return true;
@@ -74,7 +74,7 @@ namespace UsbIpServer
         public static void ShareDevice(ExportedDevice device)
         {
             var guid = Guid.NewGuid();
-            var entry = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{guid}");
+            var entry = Registry.LocalMachine.CreateSubKey(@$"{DevicesRegistryPath}\{guid}");
             entry.SetValue(DeviceFilter.VENDOR_ID, device.VendorId);
             entry.SetValue(DeviceFilter.PRODUCT_ID, device.ProductId);
             entry.SetValue(DeviceFilter.BCD_DEVICE, device.BcdDevice);
@@ -87,13 +87,13 @@ namespace UsbIpServer
 
         public static void StopSharingDevice(ExportedDevice device)
         {
-            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(devicesRegistryPath).GetSubKeyNames();
+            var deviceKeyNames = Registry.LocalMachine.CreateSubKey(DevicesRegistryPath).GetSubKeyNames();
             foreach (var keyName in deviceKeyNames)
             {
-                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{devicesRegistryPath}\{keyName}");
+                var deviceKey = Registry.LocalMachine.CreateSubKey(@$"{DevicesRegistryPath}\{keyName}");
                 if (IsDeviceMatchInRegistry(deviceKey, device))
                 {
-                    Registry.LocalMachine.DeleteSubKeyTree(@$"{devicesRegistryPath}\{keyName}");
+                    Registry.LocalMachine.DeleteSubKeyTree(@$"{DevicesRegistryPath}\{keyName}");
                 }               
             }
         }

--- a/UsbIpServer/RegistryWatcher.cs
+++ b/UsbIpServer/RegistryWatcher.cs
@@ -34,7 +34,7 @@ namespace UsbIpServer
         {
             // something changed in the registry, so check if we should unbind device
             var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
-            var devicesToUnbind = connectedDevices.Where(x => !RegistryUtils.IsDeviceAvailable(x.BusId));
+            var devicesToUnbind = connectedDevices.Where(x => !RegistryUtils.IsDeviceShared(x));
             foreach (var device in devicesToUnbind)
             {
                 if (devices.ContainsKey(device.BusId))

--- a/UsbIpServer/Server.cs
+++ b/UsbIpServer/Server.cs
@@ -35,10 +35,15 @@ namespace UsbIpServer
             return ExecuteAsync(stoppingToken);
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        public static bool IsServerRunning()
         {
             using var singleton = new Mutex(true, SingletonMutexName, out var createdNew);
-            if (!createdNew)
+            return !createdNew;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {    
+            if (IsServerRunning())
             {
                 throw new InvalidOperationException("Another instance is already running.");
             }

--- a/UsbIpServer/Server.cs
+++ b/UsbIpServer/Server.cs
@@ -44,11 +44,6 @@ namespace UsbIpServer
             }
 
             TcpListener.Start();
-
-            if (RegistryUtils.HasRegistryAccess())
-            {
-                RegistryUtils.InitializeRegistry();
-            }
             
             using var cancellationTokenRegistration = stoppingToken.Register(() => TcpListener.Stop());
 

--- a/UsbIpServer/Server.cs
+++ b/UsbIpServer/Server.cs
@@ -40,10 +40,16 @@ namespace UsbIpServer
             using var singleton = new Mutex(true, SingletonMutexName, out var createdNew);
             if (!createdNew)
             {
-                throw new InvalidOperationException("Another instance is already running");
+                throw new InvalidOperationException("Another instance is already running.");
             }
 
             TcpListener.Start();
+
+            // To start, all devices should not be marked as attached.
+            var devices = await ExportedDevice.GetAll(CancellationToken.None);
+            foreach (var device in devices) {
+                RegistryUtils.SetDeviceAsDetached(device);
+            }
             
             using var cancellationTokenRegistration = stoppingToken.Register(() => TcpListener.Stop());
 


### PR DESCRIPTION
Changes on this PR:

- The tool now allows user to persistently share their devices.
- Users can query the devices "present" and devices "persisted" with the list command. 
  - Present devices can be shared or un-shared with their bus-id. Persisted devices can be forgotten by providing a GUID.
  - Present devices include a status column which indicates if the device is "not-shared", "shared" or "attached".
- A fix to a bug which showed the name of devices as "VirtualBox USB" after being attached.

Low level changes are:
- Saving a key in the registry for every device shared. The key is a GUID. The values are filters that identify the device and VIP which is the IP address of the virtual machine to which is attached to. Additionally, every key contains a volatile subkey that indicates if the device is attached or not.
