### PR TITLE
Add WSL convenience commands

### DIFF
--- a/UsbIpServer/ConnectedClient.cs
+++ b/UsbIpServer/ConnectedClient.cs
@@ -154,15 +154,7 @@ namespace UsbIpServer
                 finally
                 {
                     Watcher.StopWatchingDevice(busid);
-
-                    if (RegistryUtils.IsDeviceSharedTemporarily(exportedDevice))
-                    {
-                        RegistryUtils.StopSharingDevice(exportedDevice);
-                    }
-                    else
-                    {
-                        RegistryUtils.SetDeviceAsDetached(exportedDevice);
-                    }
+                    RegistryUtils.SetDeviceAsDetached(exportedDevice);
 
                     Logger.LogInformation(LogEvents.ClientDetach, $"Client {ClientContext.TcpClient.Client.RemoteEndPoint} released device at {exportedDevice.BusId} ({exportedDevice.Path}).");
                 }

--- a/UsbIpServer/ConnectedClient.cs
+++ b/UsbIpServer/ConnectedClient.cs
@@ -24,12 +24,13 @@ namespace UsbIpServer
     [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by DI")]
     sealed class ConnectedClient
     {
-        public ConnectedClient(ILogger<ConnectedClient> logger, RegistryWatcher watcher, ClientContext clientContext, IServiceProvider serviceProvider)
+        public ConnectedClient(ILogger<ConnectedClient> logger, RegistryWatcher registryWatcher, DeviceChangeWatcher deviceChangeWatcher, ClientContext clientContext, IServiceProvider serviceProvider)
         {
             Logger = logger;
             ClientContext = clientContext;
             ServiceProvider = serviceProvider;
-            Watcher = watcher;
+            RegistryWatcher = registryWatcher;
+            DeviceChangeWatcher = deviceChangeWatcher;
 
             var client = clientContext.TcpClient;
             client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
@@ -44,7 +45,8 @@ namespace UsbIpServer
         readonly ClientContext ClientContext;
         readonly IServiceProvider ServiceProvider;
         readonly NetworkStream Stream;
-        readonly RegistryWatcher Watcher;
+        readonly RegistryWatcher RegistryWatcher;
+        readonly DeviceChangeWatcher DeviceChangeWatcher;
 
         public async Task RunAsync(CancellationToken cancellationToken)
         {
@@ -129,31 +131,20 @@ namespace UsbIpServer
 
                     // setup token to free device
                     using var attachedClientTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    Watcher.WatchDevice(busid, () => attachedClientTokenSource.Cancel());
+                    Action cancelAction = () => attachedClientTokenSource.Cancel();
+                    RegistryWatcher.WatchDevice(busid, cancelAction);
+                    DeviceChangeWatcher.WatchForDeviceRemoval(busid, cancelAction);
                     var attachedClientToken = attachedClientTokenSource.Token;
                     RegistryUtils.SetDeviceAsAttached(exportedDevice);
                     var iPEndPoint = ClientContext.TcpClient.Client.RemoteEndPoint as IPEndPoint;
                     RegistryUtils.SetDeviceAddress(exportedDevice, iPEndPoint!.Address.ToString());
 
-                    // Poll for the device to be unplugged
-                    var pollTask = Task.Run(async () =>
-                    {
-                        while ((await ExportedDevice.GetAll(attachedClientToken)).Any(device => device.BusId == busid))
-                        {
-                            await Task.Delay(TimeSpan.FromSeconds(1.0), attachedClientToken);
-                        }
-
-                        attachedClientTokenSource.Cancel();
-                    }, attachedClientToken);
-
                     await ServiceProvider.GetRequiredService<AttachedClient>().RunAsync(attachedClientToken);
-
-                    // If we made it this far without cancellation, cancel now to stop the polling loop.
-                    attachedClientTokenSource.Cancel();
                 }
                 finally
                 {
-                    Watcher.StopWatchingDevice(busid);
+                    RegistryWatcher.StopWatchingDevice(busid);
+                    DeviceChangeWatcher.StopWatchingDevice(busid);
                     RegistryUtils.SetDeviceAsDetached(exportedDevice);
 
                     Logger.LogInformation(LogEvents.ClientDetach, $"Client {ClientContext.TcpClient.Client.RemoteEndPoint} released device at {exportedDevice.BusId} ({exportedDevice.Path}).");

--- a/UsbIpServer/DeviceChangeWatcher.cs
+++ b/UsbIpServer/DeviceChangeWatcher.cs
@@ -1,0 +1,90 @@
+﻿// SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Management;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UsbIpServer
+{
+
+    [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by DI")]
+    sealed class DeviceChangeWatcher : IDisposable
+    {
+        readonly ManagementEventWatcher watcher;
+
+        HashSet<string>? lastKnownBusIds;
+
+        // Mapping of bus IDs to actions to take on device removal.
+        readonly Dictionary<string, Action> removalActions = new Dictionary<string, Action>();
+
+        public DeviceChangeWatcher()
+        {
+            var query = @"SELECT * FROM Win32_SystemConfigurationChangeEvent";
+
+            // We're not in an async context here, so start a task to initialize the
+            // list of known bus IDs and then forget about it. The task won't overwrite
+            // existing values if it runs too late.
+            Task.Run(async () =>
+            {
+                var busIds = await GetAllBusIdsAsync(CancellationToken.None);
+                Interlocked.CompareExchange(ref lastKnownBusIds, busIds, null);
+            });
+
+            watcher = new ManagementEventWatcher(query);
+            watcher.EventArrived += HandleEvent;
+            watcher.Start();
+        }
+
+        async void HandleEvent(object sender, EventArrivedEventArgs e)
+        {
+            var removedDevices = await GetRemovedDevicesAsync(CancellationToken.None);
+
+            foreach (var device in removedDevices)
+            {
+                if (removalActions.ContainsKey(device))
+                {
+                    removalActions[device]();
+                    StopWatchingDevice(device);
+                }
+            }
+        }
+
+        public void WatchForDeviceRemoval(string busId, Action removalAction)
+        {
+            removalActions[busId] = removalAction;
+        }
+
+        public void StopWatchingDevice(string busId)
+        {
+            removalActions.Remove(busId);
+        }
+
+        public void Dispose()
+        {
+            watcher.EventArrived -= HandleEvent;
+            watcher.Dispose();
+        }
+
+        private async Task<HashSet<string>> GetRemovedDevicesAsync(CancellationToken cancellationToken)
+        {
+            var newBusIds = await GetAllBusIdsAsync(cancellationToken);
+            lastKnownBusIds?.ExceptWith(newBusIds);
+
+            var removedDevices = lastKnownBusIds;
+            lastKnownBusIds = newBusIds;
+            return removedDevices ?? new HashSet<string>();
+        }
+
+        private static async Task<HashSet<string>> GetAllBusIdsAsync(CancellationToken cancellationToken)
+        {
+            return (await ExportedDevice.GetAll(cancellationToken)).Select(device => device.BusId).ToHashSet();
+        }
+    }
+}

--- a/UsbIpServer/NativeWslApi.cs
+++ b/UsbIpServer/NativeWslApi.cs
@@ -1,0 +1,76 @@
+﻿// SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace UsbIpServer
+{
+    class NativeWslApi
+    {
+        public enum RpcAuthnLevel
+        {
+            Default = 0,
+            None = 1,
+            Connect = 2,
+            Call = 3,
+            Pkt = 4,
+            PktIntegrity = 5,
+            PktPrivacy = 6
+        }
+
+        public enum RpcImpLevel
+        {
+            Default = 0,
+            Anonymous = 1,
+            Identify = 2,
+            Impersonate = 3,
+            Delegate = 4
+        }
+
+        public enum EoAuthnCap
+        {
+            None = 0x00,
+            MutualAuth = 0x01,
+            StaticCloaking = 0x20,
+            DynamicCloaking = 0x40,
+            AnyAuthority = 0x80,
+            MakeFullSIC = 0x100,
+            Default = 0x800,
+            SecureRefs = 0x02,
+            AccessControl = 0x04,
+            AppID = 0x08,
+            Dynamic = 0x10,
+            RequireFullSIC = 0x200,
+            AutoImpersonate = 0x400,
+            NoCustomMarshal = 0x2000,
+            DisableAAA = 0x1000
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1712:Do not prefix enum values with type name", Justification = "Matches names in official documentatino.")]
+        public enum WSL_DISTRIBUTION_FLAGS
+        {
+            WSL_DISTRIBUTION_FLAGS_NONE = 0,
+            WSL_DISTRIBUTION_FLAGS_ENABLE_INTEROP = 1,
+            WSL_DISTRIBUTION_FLAGS_APPEND_NT_PATH = 2,
+            WSL_DISTRIBUTION_FLAGS_ENABLE_DRIVE_MOUNTING = 3
+        }
+
+        // This function is not part of the WSL API, but is needed to initialize COM
+        // messaging in a way that is compatible with the WSL service.
+        // https://github.com/microsoft/WSL/issues/5824
+        [DllImport("ole32.dll")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        public static extern int CoInitializeSecurity(IntPtr pVoid, int cAuthSvc,
+            IntPtr asAuthSvc, IntPtr pReserved1, RpcAuthnLevel level, RpcImpLevel impers,
+            IntPtr pAuthList, EoAuthnCap dwCapabilities, IntPtr pReserved3);
+
+
+        [DllImport("wslapi.dll", CharSet = CharSet.Unicode)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        public static extern int WslGetDistributionConfiguration(string distributionName,
+            out ulong distributionVersion, out ulong defaultUID, out WSL_DISTRIBUTION_FLAGS wslDistributionFlags,
+            out IntPtr defaultEnvironmentVariables, out ulong defaultEnvironmentVariableCount);
+    }
+}

--- a/UsbIpServer/ProcessUtils.cs
+++ b/UsbIpServer/ProcessUtils.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UsbIpServer
+{
+    static class ProcessUtils
+    {
+        public record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+
+        public static async Task<ProcessResult> RunCapturedProcessAsync(string filename, IEnumerable<string> arguments, Encoding encoding, CancellationToken cancellationToken)
+        {
+            var startInfo = CreateCommonProcessStartInfo(filename, arguments);
+            startInfo.StandardOutputEncoding = encoding;
+            startInfo.StandardErrorEncoding = encoding;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+
+            using var process = new Process { StartInfo = startInfo };
+
+            if (!process.Start())
+            {
+                throw new UnexpectedResultException(FormatStartFailedMessage(filename, arguments));
+            }
+
+            var stdout = string.Empty;
+            var stderr = string.Empty;
+
+            await Task.WhenAll(
+                Task.Run(async () => { stdout = await process.StandardOutput.ReadToEndAsync(); }, cancellationToken),
+                Task.Run(async () => { stderr = await process.StandardError.ReadToEndAsync(); }, cancellationToken),
+                process.WaitForExitAsync(cancellationToken));
+
+            return new ProcessResult(process.ExitCode, stdout, stderr);
+        }
+
+        public static async Task<int> RunUncapturedProcessAsync(string filename, IEnumerable<string> arguments, CancellationToken cancellationToken)
+        {
+            using var process = Process.Start(CreateCommonProcessStartInfo(filename, arguments));
+
+            if (process == null)
+            {
+                throw new UnexpectedResultException(FormatStartFailedMessage(filename, arguments));
+            }
+
+            await process.WaitForExitAsync(cancellationToken);
+            return process.ExitCode;
+        }
+
+        static ProcessStartInfo CreateCommonProcessStartInfo(string filename, IEnumerable<string> arguments)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = filename,
+                UseShellExecute = false,
+            };
+
+            foreach (string argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            return startInfo;
+        }
+
+        static string FormatStartFailedMessage(string filename, IEnumerable<string> arguments)
+        {
+            return $"Failed to start \"{filename}\" with arguments {string.Join(" ", arguments.Select(arg => $"\"{arg}\""))}.";
+        }
+    }
+}

--- a/UsbIpServer/ProcessUtils.cs
+++ b/UsbIpServer/ProcessUtils.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -228,7 +228,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
                         var path = usbipPath.HasValue() ? usbipPath.Value() : "usbip";
                         var wslResult = await ProcessUtils.RunUncapturedProcessAsync(
-                            "wsl.exe",
+                            WslDistributions.WslPath,
                             (distro.HasValue() ? new[] { "--distribution", distro.Value() } : Enumerable.Empty<string>()).Concat(
                                 new[] { "--", "sudo", path, "attach", $"--remote={address}", $"--busid={busId.Value}" }),
                             CancellationToken.None);
@@ -368,7 +368,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             {
                 try
                 {
-                    var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
+                    var connectedDevices = await ExportedDevice.GetAll(cancellationToken);
                     var targetDevice = connectedDevices.Where(x => x.BusId == busId).First();
                     if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
                     {

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -56,7 +56,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
         public static string Truncate(this string value, int maxChars)
         {
-            return value.Length <= maxChars ? value : value.Substring(0, maxChars - 3) + "...";
+            return value.Length <= maxChars ? value : string.Concat(value.AsSpan(0, maxChars - 3), "...");
         }
 
         static int Main(string[] args)

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -329,6 +329,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                     services.AddScoped<ConnectedClient>();
                     services.AddScoped<AttachedClient>();
                     services.AddSingleton<RegistryWatcher>();
+                    services.AddSingleton<DeviceChangeWatcher>();
                 })
                 .Build()
                 .Run();

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -7,9 +7,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.Versioning;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -117,37 +121,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 cmd.Description = "Bind device";
                 var busId = cmd.Option("-b|--busid=<busid>", "Share device having <busid>", CommandOptionType.SingleValue);
                 var bindAll = cmd.Option("-a|--all", "Share all devices.", CommandOptionType.NoValue);
+                var temporary = cmd.Option("-t|--temporary", "Do not automatically share this device if it is reconnected.", CommandOptionType.NoValue);
                 DefaultCmdLine(cmd);
-                cmd.OnExecute(async () =>
-                {
-                    var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
-                    if (bindAll.HasValue())
-                    {
-                        foreach (var device in connectedDevices)
-                        {
-                            var checker = new DeviceInfoChecker();
-                            RegistryUtils.ShareDevice(device, checker.GetDeviceName(device));
-                        }
-
-                        return 0;
-                    }
-
-                    try
-                    {
-                        var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
-                        if (targetDevice != null && !RegistryUtils.IsDeviceShared(targetDevice))
-                        {
-                            var checker = new DeviceInfoChecker();
-                            RegistryUtils.ShareDevice(targetDevice, checker.GetDeviceName(targetDevice));
-                        }
-
-                        return 0;
-                    } catch (InvalidOperationException)
-                    {
-                        Console.Error.WriteLine("There's no device with the specified BUS-ID.");
-                        return 1;
-                    }
-                });
+                cmd.OnExecute(() => BindDeviceAsync(bindAll.HasValue(), busId.Value(), temporary.HasValue(), CancellationToken.None));
             });
 
             app.Command("unbind", (cmd) =>
@@ -157,49 +133,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 var guid = cmd.Option("-g|--guid=<guid>", "Stop sharing persisted device having <guid>", CommandOptionType.SingleValue);
                 var unbindAll = cmd.Option("-a|--all", "Stop sharing all devices.", CommandOptionType.NoValue);
                 DefaultCmdLine(cmd);
-                cmd.OnExecute(async () =>
-                {
-                    
-                    if (unbindAll.HasValue())
-                    {                        
-                        RegistryUtils.StopSharingAllDevices();
-                        return 0;
-                    }
-
-                    if (busId.HasValue())
-                    {
-                        try
-                        {
-                            var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
-                            var targetDevice = connectedDevices.Where(x => x.BusId == busId.Value()).First();
-                            if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
-                            {
-                                RegistryUtils.StopSharingDevice(targetDevice);
-                            }
-
-                            return 0;
-                        } catch (InvalidOperationException)
-                        {
-                            Console.Error.WriteLine("There's no device with the specified BUS-ID.");
-                            return 1;
-                        }   
-                    }
-
-                    if (guid.HasValue())
-                    {
-                        try
-                        {
-                            RegistryUtils.StopSharingDevice(guid.Value());
-                            return 0;
-                        } catch (ArgumentException)
-                        {
-                            Console.Error.WriteLine("There's no device with the specified GUID.");
-                            return 1;
-                        }
-                    }
-
-                    return 0;
-                });
+                cmd.OnExecute(() => UnbindDeviceAsync(unbindAll.HasValue(), busId.HasValue() ? busId.Value() : null, guid.HasValue() ? guid.Value() : null, CancellationToken.None));
             });
 
             app.Command("server", (cmd) =>
@@ -208,6 +142,128 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 DefaultCmdLine(cmd);
                 cmd.Argument("key=value", ".NET configuration override", true);
                 cmd.OnExecute(() => ExecuteServer(cmd.Arguments.Single().Values.ToArray()));
+            });
+
+            app.Command("wsl", (metacmd) =>
+            {
+                metacmd.Description = "Convenience commands for attaching devices to Windows Subsystem for Linux (WSL).";
+                DefaultCmdLine(metacmd);
+
+                metacmd.Command("list", (cmd) =>
+                {
+                    cmd.Description = "Lists all USB devices that are available for being attached into WSL.";
+                    DefaultCmdLine(cmd);
+                    cmd.OnExecute(async () =>
+                    {
+                        var distros = await WslDistributions.CreateAsync(CancellationToken.None);
+                        var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
+                        var deviceChecker = new DeviceInfoChecker();
+
+                        Console.WriteLine($"{"ID",-6}{"NAME",-43}{"STATE",-30}");
+                        foreach (var device in connectedDevices)
+                        {
+                            var isAttached = RegistryUtils.IsDeviceAttached(device);
+                            var address = RegistryUtils.GetDeviceAddress(device);
+
+                            // The WSL virtual switch is IPv4, but we persist IPv6 in the registry.
+                            if (address?.IsIPv4MappedToIPv6 ?? false)
+                            {
+                                address = address.MapToIPv4();
+                            }
+
+                            var distro = address != null ? distros.LookupByIPAddress(address)?.Name : null;
+                            var state = isAttached ? ("Attached" + (distro != null ? $" - {distro}" : string.Empty)) : "Not attached";
+                            var name = Truncate(deviceChecker.GetDeviceName(device), 42);
+
+                            Console.WriteLine($"{device.BusId,-6}{name,-43}{state,-30}");
+                        }
+
+                        return 0;
+                    });
+                });
+
+                metacmd.Command("attach", (cmd) =>
+                {
+                    cmd.Description = "Attaches a USB device to a WSL instance.";
+                    var busId = cmd.Argument("id", "Share device with this ID.");
+                    var distro = cmd.Option("--distribution", "Name of a specific WSL distribution to attach to (optional).", CommandOptionType.SingleValue);
+                    var usbipPath = cmd.Option("--usbippath", "Path in the WSL instance to the usbip client tools (optional).", CommandOptionType.SingleValue);
+                    DefaultCmdLine(cmd);
+
+                    cmd.OnExecute(async () =>
+                    {
+                        var address = NetworkInterface.GetAllNetworkInterfaces()
+                            .FirstOrDefault(nic => nic.Name.Contains("WSL", StringComparison.OrdinalIgnoreCase))?.GetIPProperties().UnicastAddresses
+                            .FirstOrDefault(ip => ip.Address.AddressFamily == AddressFamily.InterNetwork)
+                            ?.Address;
+
+                        if (address == null)
+                        {
+                            Console.Error.WriteLine("The local IP address for the WSL virtual switch could not be found.");
+                            return 1;
+                        }
+
+                        var distros = await WslDistributions.CreateAsync(CancellationToken.None);
+
+                        // Make sure the distro is running before we attach. While WSL is capable of
+                        // starting on the fly when wsl.exe is invoked, that will cause confusing behavior
+                        // where we might attach a USB device to WSL, then immediately detach it when the
+                        // WSL VM is shutdown shortly afterwards.
+                        if (distro.HasValue() && distros.LookupByName(distro.Value()) == null)
+                        {
+                            Console.Error.WriteLine($"The WSL distribution {distro.Value()} is not running or does exist.");
+                            return 1;
+                        }
+                        else if (!distro.HasValue() && distros.DefaultDistribution == null)
+                        {
+                            Console.Error.WriteLine($"The default WSL distribution is not running.");
+                            return 1;
+                        }
+
+                        // The WSL convenience always use temporary sharing. This simplifies the mental
+                        // model for the user and avoids complexity with automatically reaching back into
+                        // WSL (which might not be running) when the device is reconnected. For users that
+                        // want more control, the normal usbipd commands are always available.
+                        var bindResult = await BindDeviceAsync(bindAll: false, busId.Value, isTemporary: true, CancellationToken.None);
+                        if (bindResult != 0)
+                        {
+                            Console.Error.WriteLine($"Failed to bind device with ID \"{busId.Value}\".");
+                            return 1;
+                        }
+
+                        var path = usbipPath.HasValue() ? usbipPath.Value() : "usbip";
+                        var wslResult = await ProcessUtils.RunUncapturedProcessAsync(
+                            "wsl.exe",
+                            (distro.HasValue() ? new[] { "--distribution", distro.Value() } : Enumerable.Empty<string>()).Concat(
+                                new[] { "--", "sudo", path, "attach", $"--remote={address}", $"--busid={busId.Value}" }),
+                            CancellationToken.None);
+                        if (wslResult != 0)
+                        {
+                            Console.Error.WriteLine($"Failed to attach device with ID \"{busId.Value}\".");
+                            return 1;
+                        }
+
+                        return 0;
+                    });
+                });
+
+                metacmd.Command("detach", (cmd) =>
+                {
+                    cmd.Description = "Detaches a USB device from a WSL instance and makes it available again in Windows.";
+                    var busId = cmd.Argument("id", "Stop sharing device with this ID.");
+                    var detachAll = cmd.Option("--all", "Stop sharing all devices.", CommandOptionType.NoValue);
+                    DefaultCmdLine(cmd);
+
+                    // This command only exists for convenience. There's no extra work to do in the WSL instance.
+                    // Terminating the connection on Windows will also cause WSL to detach.
+                    cmd.OnExecute(() => UnbindDeviceAsync(detachAll.HasValue(), busId.Value, guid: null, CancellationToken.None));
+                });
+
+                metacmd.OnExecute(() =>
+                {
+                    app.ShowHelp("wsl");
+                    return 0;
+                });
             });
 
             app.OnExecute(() =>
@@ -270,6 +326,83 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 })
                 .Build()
                 .Run();
+            return 0;
+        }
+
+        static async Task<int> BindDeviceAsync(bool bindAll, string busId, bool isTemporary, CancellationToken cancellationToken)
+        {
+            var connectedDevices = await ExportedDevice.GetAll(cancellationToken);
+            if (bindAll)
+            {
+                foreach (var device in connectedDevices)
+                {
+                    var checker = new DeviceInfoChecker();
+                    RegistryUtils.ShareDevice(device, checker.GetDeviceName(device), isTemporary);
+                }
+
+                return 0;
+            }
+
+            try
+            {
+                var targetDevice = connectedDevices.Where(x => x.BusId == busId).First();
+                if (targetDevice != null && !RegistryUtils.IsDeviceShared(targetDevice))
+                {
+                    var checker = new DeviceInfoChecker();
+                    RegistryUtils.ShareDevice(targetDevice, checker.GetDeviceName(targetDevice), isTemporary);
+                }
+
+                return 0;
+            }
+            catch (InvalidOperationException)
+            {
+                Console.Error.WriteLine("There's no device with the specified BUS-ID.");
+                return 1;
+            }
+        }
+
+        static async Task<int> UnbindDeviceAsync(bool unbindAll, string? busId, string? guid, CancellationToken cancellationToken)
+        {
+            if (unbindAll)
+            {
+                RegistryUtils.StopSharingAllDevices();
+                return 0;
+            }
+
+            if (busId != null)
+            {
+                try
+                {
+                    var connectedDevices = await ExportedDevice.GetAll(CancellationToken.None);
+                    var targetDevice = connectedDevices.Where(x => x.BusId == busId).First();
+                    if (targetDevice != null && RegistryUtils.IsDeviceShared(targetDevice))
+                    {
+                        RegistryUtils.StopSharingDevice(targetDevice);
+                    }
+
+                    return 0;
+                }
+                catch (InvalidOperationException)
+                {
+                    Console.Error.WriteLine("There's no device with the specified BUS-ID.");
+                    return 1;
+                }
+            }
+
+            if (guid != null)
+            {
+                try
+                {
+                    RegistryUtils.StopSharingDevice(guid);
+                    return 0;
+                }
+                catch (ArgumentException)
+                {
+                    Console.Error.WriteLine("There's no device with the specified GUID.");
+                    return 1;
+                }
+            }
+
             return 0;
         }
     }

--- a/UsbIpServer/Server.cs
+++ b/UsbIpServer/Server.cs
@@ -57,8 +57,6 @@ namespace UsbIpServer
                 RegistryUtils.SetDeviceAsDetached(device);
             }
 
-            RegistryUtils.StopSharingTemporaryDevices();
-            
             using var cancellationTokenRegistration = stoppingToken.Register(() => TcpListener.Stop());
 
             while (true)

--- a/UsbIpServer/Server.cs
+++ b/UsbIpServer/Server.cs
@@ -42,8 +42,9 @@ namespace UsbIpServer
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-        {    
-            if (IsServerRunning())
+        {
+            using var mutex = new Mutex(true, SingletonMutexName, out var createdNew);
+            if (!createdNew)
             {
                 throw new InvalidOperationException("Another instance is already running.");
             }
@@ -55,6 +56,8 @@ namespace UsbIpServer
             foreach (var device in devices) {
                 RegistryUtils.SetDeviceAsDetached(device);
             }
+
+            RegistryUtils.StopSharingTemporaryDevices();
             
             using var cancellationTokenRegistration = stoppingToken.Register(() => TcpListener.Stop());
 

--- a/UsbIpServer/WslDistributions.cs
+++ b/UsbIpServer/WslDistributions.cs
@@ -54,7 +54,12 @@ namespace UsbIpServer
             }
 
             var runningDistrosResult = await ProcessUtils.RunCapturedProcessAsync("wsl.exe", new[] { "--list", "--quiet", "--running" }, Encoding.Unicode, cancellationToken);
+
+            // The compiler erroneously thinks that this exit code check and the
+            // ipResult exit code check below are always false.
+#pragma warning disable CA1508 // Avoid dead conditional code
             if (runningDistrosResult.ExitCode != 0)
+#pragma warning restore CA1508 // Avoid dead conditional code
             {
                 throw new UnexpectedResultException($"WSL failed to list running distributions: {runningDistrosResult.StandardError}");
             }
@@ -63,7 +68,9 @@ namespace UsbIpServer
             foreach (var distroName in runningDistrosResult.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
                 var ipResult = await ProcessUtils.RunCapturedProcessAsync("wsl.exe", new[] { "--distribution", distroName, "--", "hostname", "-I" }, Encoding.UTF8, cancellationToken);
+#pragma warning disable CA1508 // Avoid dead conditional code
                 if (ipResult.ExitCode != 0)
+#pragma warning restore CA1508 // Avoid dead conditional code
                 {
                     // Ignore this distro if we couldn't get an IP address.
                     continue;

--- a/UsbIpServer/WslDistributions.cs
+++ b/UsbIpServer/WslDistributions.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UsbIpServer
+{
+    class WslDistributions
+    {
+        public record Distribution(string Name, IPAddress IPAddress);
+
+        readonly string? defaultDistro;
+
+        WslDistributions(List<Distribution> distributions, string? defaultDistro)
+        {
+            this.Distributions = distributions;
+            this.defaultDistro = defaultDistro;
+        }
+
+        public IReadOnlyCollection<Distribution> Distributions { get; }
+
+        public Distribution? DefaultDistribution => defaultDistro != null ? LookupByName(defaultDistro) : null;
+
+        public static async Task<WslDistributions> CreateAsync(CancellationToken cancellationToken)
+        {
+            var allDistrosResult = await ProcessUtils.RunCapturedProcessAsync("wsl.exe", new[] { "--list" }, Encoding.Unicode, cancellationToken);
+            if (allDistrosResult.ExitCode != 0)
+            {
+                throw new UnexpectedResultException($"WSL failed to list distributions: {allDistrosResult.StandardError}");
+            }
+
+            // Sample output:
+            //   Windows Subsystem for Linux Distributions:
+            //   Ubuntu(Default)
+            // We skip the first line, then look for a "(" to mark the default distro.
+            // This is similar to how Windows Terminal handles WSL.
+            // https://github.com/microsoft/terminal/blob/9e83655b0870f7964789a7a17ccfd232cab4945a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp#L120
+            var defaultDistro = allDistrosResult.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+                .Skip(1).FirstOrDefault(d => d.Contains('(', StringComparison.Ordinal));
+            if (defaultDistro != null)
+            {
+                var firstNonNameChar = defaultDistro.IndexOf('(', StringComparison.Ordinal);
+                if (firstNonNameChar != -1)
+                {
+                    defaultDistro = defaultDistro.Substring(0, firstNonNameChar).Trim();
+                }
+            }
+
+            var runningDistrosResult = await ProcessUtils.RunCapturedProcessAsync("wsl.exe", new[] { "--list", "--quiet", "--running" }, Encoding.Unicode, cancellationToken);
+            if (runningDistrosResult.ExitCode != 0)
+            {
+                throw new UnexpectedResultException($"WSL failed to list running distributions: {runningDistrosResult.StandardError}");
+            }
+
+            var distros = new List<Distribution>();
+            foreach (var distroName in runningDistrosResult.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var ipResult = await ProcessUtils.RunCapturedProcessAsync("wsl.exe", new[] { "--distribution", distroName, "--", "hostname", "-I" }, Encoding.UTF8, cancellationToken);
+                if (ipResult.ExitCode != 0)
+                {
+                    // Ignore this distro if we couldn't get an IP address.
+                    continue;
+                }
+
+                // hostname output sometimes includes whitespace at the end, so trim before parsing.
+                distros.Add(new Distribution(distroName, IPAddress.Parse(ipResult.StandardOutput.Trim())));
+            }
+
+            return new WslDistributions(distros, defaultDistro);
+        }
+
+        public Distribution? LookupByName(string name) => this.Distributions.FirstOrDefault(distro => distro.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        public Distribution? LookupByIPAddress(IPAddress address) => this.Distributions.FirstOrDefault(distro => distro.IPAddress.Equals(address));
+    }
+}

--- a/UsbIpServer/WslDistributions.cs
+++ b/UsbIpServer/WslDistributions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/UsbIpServer/WslDistributions.cs
+++ b/UsbIpServer/WslDistributions.cs
@@ -89,7 +89,7 @@ namespace UsbIpServer
                         version = knownVersion;
                     }
                 }
-                catch (DllNotFoundException ex)
+                catch (DllNotFoundException)
                 {
                     // For some reason the WSL API couldn't be loaded.
                     // We'll just leave the version set to null (unknown).

--- a/UsbIpServer/WslDistributions.cs
+++ b/UsbIpServer/WslDistributions.cs
@@ -19,6 +19,8 @@ namespace UsbIpServer
 
         public record Distribution(string Name, IPAddress IPAddress);
 
+        public static bool IsWslInstalled() => File.Exists(WslPath);
+
         readonly string? defaultDistro;
 
         WslDistributions(List<Distribution> distributions, string? defaultDistro)

--- a/WSL_USBIP.md
+++ b/WSL_USBIP.md
@@ -4,6 +4,55 @@ SPDX-FileCopyrightText: Microsoft Corporation
 SPDX-License-Identifier: GPL-2.0-only
 -->
 
+# WSL convenience commands
+
+After following the setup instructions below, you can use the WSL convenience
+commands to easily attach devices to a WSL instance and view which distributions
+devices are attached to.
+
+```
+> usbipd wsl list
+ID    NAME                                       STATE
+1-7   USB Input Device                           Not attached
+4-4   STMicroelectronics STLink dongle, STMic... Not attached
+5-2   Surface Ethernet Adapter                   Not attached
+
+> usbipd wsl attach 4-4
+[sudo] password for user:
+
+> usbipd wsl list
+ID    NAME                                       STATE
+1-7   USB Input Device                           Not attached
+4-4   STMicroelectronics STLink dongle, STMic... Attached - Ubuntu
+5-2   Surface Ethernet Adapter                   Not attached
+```
+
+Now the device is available in WSL.
+
+```
+$ lsusb
+Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+Bus 001 Device 002: ID 0483:374b STMicroelectronics ST-LINK/V2.1
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+```
+
+`wsl detach` can be used to stop sharing the device. The device will also
+automatically stop sharing if it is unplugged or the computer is restarted.
+
+```
+> usbipd wsl detach 4-4
+
+> usbipd wsl list
+ID    NAME                                       STATE
+1-7   USB Input Device                           Not attached
+4-4   STMicroelectronics STLink dongle, STMic... Not attached
+5-2   Surface Ethernet Adapter                   Not attached
+```
+
+Use the `--help` to learn more about these convenience commands. In particular,
+the `--distribution` and `--usbippath` options can be useful to customize how
+the WSL commands are invoked.
+
 # Setting up USBIP on WSL 2
 
 Update WSL:

--- a/WSL_USBIP.md
+++ b/WSL_USBIP.md
@@ -10,7 +10,7 @@ After following the setup instructions below, you can use the WSL convenience
 commands to easily attach devices to a WSL instance and view which distributions
 devices are attached to.
 
-```
+```pwsh
 > usbipd wsl list
 ID    NAME                                       STATE
 1-7   USB Input Device                           Not attached
@@ -29,7 +29,7 @@ ID    NAME                                       STATE
 
 Now the device is available in WSL.
 
-```
+```bash
 $ lsusb
 Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
 Bus 001 Device 002: ID 0483:374b STMicroelectronics ST-LINK/V2.1
@@ -39,7 +39,7 @@ Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 `wsl detach` can be used to stop sharing the device. The device will also
 automatically stop sharing if it is unplugged or the computer is restarted.
 
-```
+```pwsh
 > usbipd wsl detach 4-4
 
 > usbipd wsl list


### PR DESCRIPTION
Documentation for the new commands is available in the `WSL_USBIP.md` document. These changes provide a single command that allows users to share devices with a WSL instance. It takes care of sharing the device in the server and attaching the device from Linux, and makes it so that users don't need to know their IP address on Windows or Linux.

I also fixed a bug with the `IsServerRunning` mutex.

@NelsonDaniel adding you in case you're interested, but I know this is your last day, so don't feel like you need to review this.