### PR TITLE
Improve WSL handling

### DIFF
--- a/UsbIpServer/NativeMethods.txt
+++ b/UsbIpServer/NativeMethods.txt
@@ -64,8 +64,3 @@ METHOD_BUFFERED
 
 FILE_ANY_ACCESS
 FILE_WRITE_ACCESS
-
-CoInitializeSecurity
-WslGetDistributionConfiguration
-
-S_OK

--- a/UsbIpServer/RegistryUtils.cs
+++ b/UsbIpServer/RegistryUtils.cs
@@ -115,7 +115,7 @@ namespace UsbIpServer
 
         public static void StopSharingDevice(Guid guid)
         {
-            using var devicesKey = GetDevicesKey(false);
+            using var devicesKey = GetDevicesKey(true);
             devicesKey.DeleteSubKeyTree(guid.ToString("B"), false);
         }
 

--- a/UsbIpServer/WslDistributions.cs
+++ b/UsbIpServer/WslDistributions.cs
@@ -4,14 +4,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management;
 using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Windows.Win32;
 
 namespace UsbIpServer
 {
@@ -19,13 +22,17 @@ namespace UsbIpServer
     {
         public static readonly string WslPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "wsl.exe");
 
-        public record Distribution(string Name, IPAddress IPAddress, uint? Version);
+        public record Distribution(string Name, bool IsDefault, uint Version, bool IsRunning, IPAddress? IPAddress);
 
-        public static bool IsWslInstalled()
+        public static bool IsWsl2Installed()
         {
+            // Since WSL 2, the wsl.exe command is used to manage WSL.
+            // And since USBIP requires a real kernel (i.e. WSL 2), we may safely assume that wsl.exe is available.
+            // Users with older (< 1903) Windows will simply get a report that WSL 2 is not available,
+            //    even if they have WSL (version 1) installed. It won't work for them anyway.
+            // We won't bother checking for the older wslconfig.exe that was used to manage WSL 1.
             if (!File.Exists(WslPath))
             {
-                // Definitely not installed.
                 return false;
             }
             // On recent Windows 10, wsl.exe will be available even if the WSL feature is not installed.
@@ -35,102 +42,107 @@ namespace UsbIpServer
             return collection.Count == 1;
         }
 
-        readonly string? DefaultDistro;
-
-        WslDistributions(List<Distribution> distributions, string? defaultDistro)
+        WslDistributions(List<Distribution> distributions, IPAddress? hostAddress)
         {
             Distributions = distributions;
-            DefaultDistro = defaultDistro;
+            HostAddress = hostAddress;
         }
 
         public IReadOnlyCollection<Distribution> Distributions { get; }
 
-        public Distribution? DefaultDistribution => DefaultDistro is not null ? LookupByName(DefaultDistro) : null;
+        public IPAddress? HostAddress { get; }
+
+        public Distribution? DefaultDistribution => Distributions.FirstOrDefault((distro) => distro.IsDefault);
+
+        static bool IsOnSameIPv4Network(UnicastIPAddressInformation wslHost, IPAddress wslInstance)
+        {
+            if (wslHost.Address.AddressFamily != AddressFamily.InterNetwork
+                || wslInstance.AddressFamily != AddressFamily.InterNetwork)
+            {
+                return false;
+            }
+
+            // NOTE: we don't care about byte order here
+            var rawHost = BitConverter.ToUInt32(wslHost.Address.GetAddressBytes());
+            var rawInstance = BitConverter.ToUInt32(wslInstance.GetAddressBytes());
+            var rawMask = BitConverter.ToUInt32(wslHost.IPv4Mask.GetAddressBytes());
+            return (rawHost & rawMask) == (rawInstance & rawMask);
+        }
 
         public static async Task<WslDistributions> CreateAsync(CancellationToken cancellationToken)
         {
-            var allDistrosResult = await ProcessUtils.RunCapturedProcessAsync(WslPath, new[] { "--list" }, Encoding.Unicode, cancellationToken);
-            if (allDistrosResult.ExitCode != 0)
-            {
-                throw new UnexpectedResultException($"WSL failed to list distributions: {allDistrosResult.StandardError}");
-            }
+            var wslHost = NetworkInterface.GetAllNetworkInterfaces()
+                .FirstOrDefault(nic => nic.Name.Contains("WSL", StringComparison.OrdinalIgnoreCase))?.GetIPProperties().UnicastAddresses
+                .FirstOrDefault(ip => ip.Address.AddressFamily == AddressFamily.InterNetwork);
 
+            // Get a list of details of available distros (in any state: Stopped, Running, Installing, etc.)
+            // This contains all we need (default, name, state, version).
+            // NOTE: WslGetDistributionConfiguration() is unreliable getting the version.
+            //
             // Sample output:
-            //   Windows Subsystem for Linux Distributions:
-            //   Ubuntu(Default)
-            // We skip the first line, then look for a "(" to mark the default distro.
-            // This is similar to how Windows Terminal handles WSL.
-            // https://github.com/microsoft/terminal/blob/9e83655b0870f7964789a7a17ccfd232cab4945a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp#L120
-            var defaultDistro = allDistrosResult.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-                .Skip(1).FirstOrDefault(d => d.Contains('(', StringComparison.Ordinal));
-            if (defaultDistro is not null)
+            //   NAME               STATE           VERSION
+            // * Ubuntu             Running         1
+            //   Debian             Stopped         2
+            //   Custom-MyDistro    Running         2
+            var detailsResult = await ProcessUtils.RunCapturedProcessAsync(WslPath, new[] { "--list", "--all", "--verbose" }, Encoding.Unicode, cancellationToken);
+            if (detailsResult.ExitCode != 0)
             {
-                var firstNonNameChar = defaultDistro.IndexOf('(', StringComparison.Ordinal);
-                if (firstNonNameChar != -1)
-                {
-                    defaultDistro = defaultDistro.Substring(0, firstNonNameChar).Trim();
-                }
+                throw new UnexpectedResultException($"WSL failed to list distributions: {detailsResult.StandardError}");
             }
+            var details = detailsResult.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
 
-            var runningDistrosResult = await ProcessUtils.RunCapturedProcessAsync(WslPath, new[] { "--list", "--quiet", "--running" }, Encoding.Unicode, cancellationToken);
-
-            // The compiler erroneously thinks that this exit code check and the
-            // ipResult exit code check below are always false.
-#pragma warning disable CA1508 // Avoid dead conditional code
-            if (runningDistrosResult.ExitCode != 0)
-#pragma warning restore CA1508 // Avoid dead conditional code
+            // Sanity check
+            if (!Regex.IsMatch(details.FirstOrDefault() ?? string.Empty, "^  NAME +STATE +VERSION *$"))
             {
-                throw new UnexpectedResultException($"WSL failed to list running distributions: {runningDistrosResult.StandardError}");
+                throw new UnexpectedResultException($"WSL failed to parse distributions: {detailsResult.StandardOutput}");
             }
 
             var distros = new List<Distribution>();
-            foreach (var distroName in runningDistrosResult.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            foreach (var line in details.Skip(1))
             {
-                var ipResult = await ProcessUtils.RunCapturedProcessAsync(WslPath, new[] { "--distribution", distroName, "--", "hostname", "-I" }, Encoding.UTF8, cancellationToken);
-#pragma warning disable CA1508 // Avoid dead conditional code
-                if (ipResult.ExitCode != 0)
-#pragma warning restore CA1508 // Avoid dead conditional code
+                var match = Regex.Match(line, @"^( |\*) (.+) +([a-zA-Z]+) +([0-9])+ *$");
+                if (!match.Success)
                 {
-                    // Ignore this distro if we couldn't get an IP address.
-                    continue;
+                    throw new UnexpectedResultException($"WSL failed to parse distributions: {detailsResult.StandardOutput}");
                 }
+                var isDefault = match.Groups[1].Value == "*";
+                var name = match.Groups[2].Value.TrimEnd();
+                var isRunning = match.Groups[3].Value == "Running";
+                var version = uint.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture);
 
-                uint? version = null;
-                try
+                IPAddress? address = null;
+                if (wslHost is not null && isRunning && version == 2)
                 {
-                    unsafe
+                    // We'll do our best to get the instance address on the WSL virtual switch, but we don't fail if we can't.
+                    // 'hostname' is run on the WSL instance and returns a <space> separated list of addresses, both IPv4 and IPv6.
+                    var ipResult = await ProcessUtils.RunCapturedProcessAsync(WslPath, new[] { "--distribution", name, "--", "hostname", "--all-ip-addresses" }, Encoding.UTF8, cancellationToken);
+#pragma warning disable CA1508 // Avoid dead conditional code (false positive)
+                    if (ipResult.ExitCode == 0)
+#pragma warning restore CA1508 // Avoid dead conditional code
                     {
-                        if (PInvoke.WslGetDistributionConfiguration(distroName, out var knownVersion, out _, out _, out _, out _) == Constants.S_OK)
+                        foreach (var a in ipResult.StandardOutput.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                         {
-                            version = knownVersion;
+                            if (!IPAddress.TryParse(a, out var wslInstance))
+                            {
+                                continue;
+                            }
+                            if (IsOnSameIPv4Network(wslHost, wslInstance))
+                            {
+                                address = wslInstance;
+                                break;
+                            }
                         }
                     }
                 }
-                catch (DllNotFoundException)
-                {
-                    // For some reason the WSL API couldn't be loaded.
-                    // We'll just leave the version set to null (unknown).
-                }
 
-                // hostname can include multiple IP addresses, but in most cases there's
-                // only one. Since we don't have a good way to figure out which one is the
-                // WSL virtual switch, just take the first one and hope it's correct.
-                var firstAddress = ipResult.StandardOutput.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
-
-                if (firstAddress is null || !IPAddress.TryParse(firstAddress, out var address))
-                {
-                    // Ignore this distro if the IP address coudn't be parsed.
-                    continue;
-                }
-
-                distros.Add(new Distribution(distroName, address, version));
+                distros.Add(new Distribution(name, isDefault, version, isRunning, address));
             }
 
-            return new WslDistributions(distros, defaultDistro);
+            return new WslDistributions(distros, wslHost?.Address);
         }
 
         public Distribution? LookupByName(string name) => Distributions.FirstOrDefault(distro => distro.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
-        public Distribution? LookupByIPAddress(IPAddress address) => Distributions.FirstOrDefault(distro => distro.IPAddress.Equals(address));
+        public Distribution? LookupByIPAddress(IPAddress address) => Distributions.FirstOrDefault(distro => address.Equals(distro.IPAddress));
     }
 }

--- a/WSL_USBIP.md
+++ b/WSL_USBIP.md
@@ -64,31 +64,36 @@ wsl --update
 List your distributions.
 
 ```pwsh
-wsl list
+wsl --list --vebose
 ```
+
+Verify that your target distribution is version 2;
+see [WSL documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10#set-your-distribution-version-to-wsl-1-or-wsl-2)
+for instructions on how to set the WSL version.
 
 Export current distribution to be able to fall back if something goes wrong.
 
 ```pwsh
-wsl --export Ubuntu-20.04 <temporary-distro-path>\Ubuntu-usbip.tar
+wsl --export <current-distro> <temporary-path>\wsl2-usbip.tar
 ```
 
 Import new distribution with current distribution as base.
 
 ```pwsh
-wsl --import Ubuntu-usbip <temporary-distro-path>\Ubuntu-usbip.tar <temporary-distro-path>\Ubuntu.tar
+wsl --import wsl2-usbip <install-path> <temporary-path>\wsl2-usbip.tar
 ```
 
 Run new distribution.
 
 ```pwsh
-wsl --distribution Ubuntu-usbip --user <user>
+wsl --distribution wsl2-usbip --user <user>
 ```
 
-Update resources.
+Update resources (assuming `apt`, you may need to use `yum` or another package manager).
 
 ```bash
 sudo apt update
+sudo apt upgrade
 ```
 
 Install prerequisites.


### PR DESCRIPTION
- fix version detection (WSL API returned unreliable results)
- improve instance IP address detection
- improve attach prerequisites checks
- silence bogus "already shared" info message
- improve documentation

Additional fixes:

- normalize table headers to CAPITALIZED (just like wsl.exe)
- all console reporting to stderr
- check server running
- fix double 'list' header
- fix 'unbind' registry access