### PR TITLE
Add lock for thread safety in DeviceChangeWatcher

### DIFF
--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -433,7 +433,7 @@ a 'usbip attach' command on the Linux side.
 
                         if (distros.HostAddress is null)
                         {
-                            ReportError("The local IP address for the WSL virtual switch could not be found.");
+                            ReportError("The local IP address for the WSL virtual switch could not be found. Ensure WSL is running.");
                             return 1;
                         }
 


### PR DESCRIPTION
I was running into some weird issues where a `NullReferenceException` was sometimes thrown by [`SortedSet.Node.Rotate()`](https://source.dot.net/#System.Collections/System/Collections/Generic/SortedSet.cs,1766) when called by this line in `GetRemovedDevicesAsync()`.

```csharp
lastKnownBusIds?.ExceptWith(newBusIds);
```

I wasn't able to completely track down the root cause of the issue, but I did notice that `GetRemovedDevicesAsync()` was repeatedly called by different worker threads during debugging, so I suspect two threads were trying to access the `SortedSet` at the same time and corrupted the state of the internal tree. This PR adds a semaphore to lock access to the members of `DeviceChangeWatcher`

I also added a note to the error message when the WSL switch IP address can't be found, because this can be caused by WSL not running.