### PR TITLE
Add support for intr/unlink and concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ Instructions on how to setup a Linux usbip client can be found [here](WSL_USBIP.
 
 ## Limitations
 
-- For now, only USB devices with so called *bulk* endpoints work (USB flash drives, FTDI USB-to-serial, etc.).
+- For now, *isochronous* USB devices are not supported, such as audio and video devices.
 
 More information can be found on the [wiki](https://github.com/dorssel/usbipd-win/wiki).

--- a/UsbIpServer/AttachedClient.cs
+++ b/UsbIpServer/AttachedClient.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
@@ -42,9 +43,14 @@ namespace UsbIpServer
         readonly NetworkStream Stream;
         readonly DeviceFile Device;
         readonly UsbConfigurationDescriptors ConfigurationDescriptors;
+        readonly SemaphoreSlim WriteMutex = new(1);
+        readonly object PendingSubmitsLock = new();
+        readonly SortedSet<uint> PendingSubmits = new();
 
         async Task HandleSubmitAsync(UsbIpHeaderBasic basic, UsbIpHeaderCmdSubmit submit, CancellationToken cancellationToken)
         {
+            // We are synchronous with the receiver.
+
             var transferType = ConfigurationDescriptors.GetEndpointType(basic.ep, basic.direction == UsbIpDir.USBIP_DIR_IN);
 
             var urb = new UsbSupUrb()
@@ -73,10 +79,8 @@ namespace UsbIpServer
                     urb.type = UsbSupTransferType.USBSUP_TRANSFER_TYPE_BULK;
                     break;
                 case Constants.USB_ENDPOINT_TYPE_INTERRUPT:
-                    // TODO: requires queuing reuests and handling USBIP_CMD_UNLINK
-                    // urb.type = UsbSupTransferType.USBSUP_TRANSFER_TYPE_INTR;
-                    // break;
-                    throw new NotImplementedException("USB_ENDPOINT_TYPE_INTERRUPT");
+                    urb.type = UsbSupTransferType.USBSUP_TRANSFER_TYPE_INTR;
+                    break;
                 case Constants.USB_ENDPOINT_TYPE_ISOCHRONOUS:
                     throw new NotImplementedException("USB_ENDPOINT_TYPE_ISOCHRONOUS");
                 default:
@@ -102,6 +106,18 @@ namespace UsbIpServer
                 throw new NotImplementedException("ISO transfers");
             }
 
+            // We now have received the entire SUBMIT request:
+            // - If the request is "special" (reconfig, clear), then we will handle it immediately and await the result.
+            //   This means no further requests will be read until the special request has completed.
+            // - Otherwise, we will start a new task so that the receiver can continue.
+            //   This means multiple URBs can be outstanding awaiting completion.
+            //   The pending URBs can be completed out of order, but the replies must be sent atomically.
+
+            Task ioctl;
+            // Boxed into a class, so we can use Interlocked with null.
+            object? gcHandle = null;
+            var pending = false;
+
             if ((basic.ep == 0)
                 && (submit.setup.bmRequestType.B == Constants.BMREQUEST_TO_DEVICE)
                 && (submit.setup.bRequest == Constants.USB_REQUEST_SET_CONFIGURATION))
@@ -112,7 +128,8 @@ namespace UsbIpServer
                     bConfigurationValue = submit.setup.wValue.Anonymous.LowByte,
                 };
                 Logger.LogDebug($"Trapped SET_CONFIGURATION: {setConfig.bConfigurationValue}");
-                await Device.IoControlAsync(IoControl.SUPUSB_IOCTL_USB_SET_CONFIG, StructToBytes(setConfig), null);
+                ioctl = Device.IoControlAsync(IoControl.SUPUSB_IOCTL_USB_SET_CONFIG, StructToBytes(setConfig), null);
+                await ioctl;
                 ConfigurationDescriptors.SetConfiguration(setConfig.bConfigurationValue);
             }
             else if ((basic.ep == 0)
@@ -126,7 +143,8 @@ namespace UsbIpServer
                     bAlternateSetting = submit.setup.wValue.Anonymous.LowByte,
                 };
                 Logger.LogDebug($"Trapped SET_INTERFACE: {selectInterface.bInterfaceNumber} -> {selectInterface.bAlternateSetting}");
-                await Device.IoControlAsync(IoControl.SUPUSB_IOCTL_USB_SELECT_INTERFACE, StructToBytes(selectInterface), null);
+                ioctl = Device.IoControlAsync(IoControl.SUPUSB_IOCTL_USB_SELECT_INTERFACE, StructToBytes(selectInterface), null);
+                await ioctl;
                 ConfigurationDescriptors.SetInterface(selectInterface.bInterfaceNumber, selectInterface.bAlternateSetting);
             }
             else if ((basic.ep == 0)
@@ -140,65 +158,144 @@ namespace UsbIpServer
                     bEndpoint = submit.setup.wIndex.Anonymous.LowByte,
                 };
                 Logger.LogDebug($"Trapped CLEAR_FEATURE: {clearEndpoint.bEndpoint}");
-                await Device.IoControlAsync(IoControl.SUPUSB_IOCTL_USB_CLEAR_ENDPOINT, StructToBytes(clearEndpoint), null);
+                ioctl = Device.IoControlAsync(IoControl.SUPUSB_IOCTL_USB_CLEAR_ENDPOINT, StructToBytes(clearEndpoint), null);
+                await ioctl;
             }
             else
             {
                 if (transferType == Constants.USB_ENDPOINT_TYPE_CONTROL)
                 {
-                    Logger.LogTrace($"{submit.setup.bmRequestType} {submit.setup.bRequest} {submit.setup.wValue} {submit.setup.wIndex} {submit.setup.wLength}");
+                    Logger.LogTrace($"{submit.setup.bmRequestType} {submit.setup.bRequest} {submit.setup.wValue.W} {submit.setup.wIndex.W} {submit.setup.wLength}");
                 }
-                var gc = GCHandle.Alloc(buf, GCHandleType.Pinned);
+                lock (PendingSubmitsLock)
+                {
+                    if (!PendingSubmits.Add(basic.seqnum))
+                    {
+                        throw new ProtocolViolationException($"duplicate sequence number {basic.seqnum}");
+                    }
+                }
+                pending = true;
+                // We need to keep the pinning alive until after the ioctl completes, but we must
+                // also free it whatever happens.
+                Interlocked.Exchange(ref gcHandle, GCHandle.Alloc(buf, GCHandleType.Pinned));
                 try
                 {
-                    urb.buf = gc.AddrOfPinnedObject();
+                    urb.buf = ((GCHandle?)gcHandle)!.Value.AddrOfPinnedObject();
                     StructToBytes(urb, bytes);
-                    await Device.IoControlAsync(IoControl.SUPUSB_IOCTL_SEND_URB, bytes, bytes);
+                    ioctl = Device.IoControlAsync(IoControl.SUPUSB_IOCTL_SEND_URB, bytes, bytes);
+                    _ = ioctl.ContinueWith((task) =>
+                    {
+                        // This acts as a "finally" clause *after* the ioctl completes.
+                        ((GCHandle?)Interlocked.Exchange(ref gcHandle, null))?.Free();
+                        return Task.CompletedTask;
+                    }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                }
+                catch
+                {
+#pragma warning disable CA1508 // Avoid dead conditional code (false positive)
+                    ((GCHandle?)Interlocked.Exchange(ref gcHandle, null))?.Free();
+#pragma warning restore CA1508 // Avoid dead conditional code
+                    throw;
+                }
+            }
+
+            // At this point we have initiated the ioctl (and possibly awaited it for special cases).
+            // Now we schedule a continuation to write the reponse once the ioctl completes.
+            // This is fire-and-forget; we'll return to the caller so it can already receive the next request.
+
+            _ = ioctl.ContinueWith(async (task, state) =>
+            {
+                using var writeLock = await Lock.CreateAsync(WriteMutex, cancellationToken);
+
+                // Now we are synchronous with the sender.
+
+                if (pending)
+                {
+                    lock (PendingSubmitsLock)
+                    {
+                        // We are racing with possible UNLINK commands.
+                        if (!PendingSubmits.Remove(basic.seqnum))
+                        {
+                            // Apparently, the client has already UNLINK-ed (canceled) the request; we're done.
+                            return;
+                        }
+                    }
                     BytesToStruct(bytes, out urb);
                 }
-                finally
+
+                var retSubmit = new UsbIpHeaderRetSubmit()
                 {
-                    gc.Free();
+                    status = -(int)ConvertError(urb.error),
+                    actual_length = (int)urb.len,
+                    start_frame = submit.start_frame,
+                    number_of_packets = (int)urb.numIsoPkts,
+                    error_count = 0,
+                };
+
+                if (transferType == Constants.USB_ENDPOINT_TYPE_CONTROL)
+                {
+                    retSubmit.actual_length = (retSubmit.actual_length > payloadOffset) ? (retSubmit.actual_length - payloadOffset) : 0;
                 }
-            }
 
-            basic.command = UsbIpCmd.USBIP_RET_SUBMIT;
-            var retSubmit = new UsbIpHeaderRetSubmit()
-            {
-                status = -(int)ConvertError(urb.error),
-                actual_length = (int)urb.len,
-                start_frame = submit.start_frame,
-                number_of_packets = (int)urb.numIsoPkts,
-                error_count = 0,
-            };
+                if (urb.error != UsbSupError.USBSUP_XFER_OK)
+                {
+                    Logger.LogDebug($"{urb.error} -> {ConvertError(urb.error)} -> {retSubmit.status}");
+                }
+                Logger.LogTrace($"actual: {retSubmit.actual_length}, requested: {requestLength}");
 
-            if (transferType == Constants.USB_ENDPOINT_TYPE_CONTROL)
-            {
-                retSubmit.actual_length = (retSubmit.actual_length > payloadOffset) ? (retSubmit.actual_length - payloadOffset) : 0;
-            }
+                var retBuf = new byte[48 /* sizeof(usbip_header) */];
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(0), (uint)UsbIpCmd.USBIP_RET_SUBMIT);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(4), basic.seqnum);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(8), 0);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(12), 0);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(16), 0);
+                BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(20), retSubmit.status);
+                BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(24), retSubmit.actual_length);
+                BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(28), retSubmit.start_frame);
+                BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(32), retSubmit.number_of_packets);
+                BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(36), retSubmit.error_count);
+                await Stream.WriteAsync(retBuf, cancellationToken);
+                if (basic.direction == UsbIpDir.USBIP_DIR_IN)
+                {
+                    await Stream.WriteAsync(buf.AsMemory(payloadOffset, retSubmit.actual_length), cancellationToken);
+                }
+            }, cancellationToken, TaskScheduler.Default);
+        }
 
-            if (urb.error != UsbSupError.USBSUP_XFER_OK)
-            {
-                Logger.LogDebug($"{urb.error} -> {ConvertError(urb.error)} -> {retSubmit.status}");
-            }
-            Logger.LogTrace($"actual: {retSubmit.actual_length}, requested: {requestLength}");
+        Task HandleUnlinkAsync(UsbIpHeaderBasic basic, UsbIpHeaderCmdUnlink unlink, CancellationToken cancellationToken)
+        {
+            // We are synchronous with the receiver.
 
-            var retBuf = new byte[48 /* sizeof(usbip_header) */];
-            BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(0), (uint)basic.command);
-            BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(4), basic.seqnum);
-            BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(8), basic.devid);
-            BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(12), (uint)basic.direction);
-            BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(16), basic.ep);
-            BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(20), retSubmit.status);
-            BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(24), retSubmit.actual_length);
-            BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(28), retSubmit.start_frame);
-            BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(32), retSubmit.number_of_packets);
-            BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(36), retSubmit.error_count);
-            await Stream.WriteAsync(retBuf, cancellationToken);
-            if (basic.direction == UsbIpDir.USBIP_DIR_IN)
+            // UNLINK requires no further reads, so we schedule a new task and let the receiver continue.
+
+            Task.Run(async () =>
             {
-                await Stream.WriteAsync(buf.AsMemory(payloadOffset, retSubmit.actual_length), cancellationToken);
-            }
+                using var writeLock = await Lock.CreateAsync(WriteMutex, cancellationToken);
+
+                // Now we are synchronous with the sender.
+
+                // We cannot actually cancel the ioctl as VBoxUSB does not support that.
+                // So, we will simply return "as if" we canceled it and simply let the
+                //    ioctl complete whenever it feels like it and ignore the result.
+                // TODO: Maybe we should reset the pipe that the original URB was for?
+
+                var retUnlink = new UsbIpHeaderRetUnlink();
+                lock (PendingSubmitsLock)
+                {
+                    // We are racing with the ioctl completion.
+                    retUnlink.status = -(int)(PendingSubmits.Remove(unlink.seqnum) ? Interop.Linux.Errno.ECONNRESET : Interop.Linux.Errno.SUCCESS);
+                }
+                var retBuf = new byte[48 /* sizeof(usbip_header) */];
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(0), (uint)UsbIpCmd.USBIP_RET_UNLINK);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(4), basic.seqnum);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(8), 0);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(12), 0);
+                BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(16), 0);
+                BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(20), retUnlink.status);
+                await Stream.WriteAsync(retBuf.AsMemory(), cancellationToken);
+            }, cancellationToken);
+
+            return Task.CompletedTask;
         }
 
         public async Task RunAsync(CancellationToken cancellationToken)
@@ -232,30 +329,13 @@ namespace UsbIpServer
                         await HandleSubmitAsync(basic, submit, cancellationToken);
                         break;
                     case UsbIpCmd.USBIP_CMD_UNLINK:
-#if true
-                        throw new NotImplementedException();
-#else
-                        Logger.LogTrace($"USBIP_CMD_UNLINK, {basic.seqnum}");
-                        var cmdUnlink = new UsbIpHeaderCmdUnlink
+                        var unlink = new UsbIpHeaderCmdUnlink
                         {
                             seqnum = BinaryPrimitives.ReadUInt32BigEndian(buf.AsSpan(20)),
                         };
-                        // just return success, TODO
-                        basic.command = UsbIpCmd.USBIP_RET_UNLINK;
-                        var retUnlink = new UsbIpHeaderRetUnlink
-                        {
-                            status = 0,
-                        };
-                        var retBuf = new byte[48 /* sizeof(usbip_header) */];
-                        BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(0), (uint)basic.command);
-                        BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(4), basic.seqnum);
-                        BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(8), basic.devid);
-                        BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(12), (uint)basic.direction);
-                        BinaryPrimitives.WriteUInt32BigEndian(retBuf.AsSpan(16), basic.ep);
-                        BinaryPrimitives.WriteInt32BigEndian(retBuf.AsSpan(20), retUnlink.status);
-                        await Stream.WriteAsync(retBuf.AsMemory(), cancellationToken);
+                        Logger.LogTrace($"USBIP_CMD_UNLINK, seqnum={basic.seqnum}, unlink_seqnum={unlink.seqnum}");
+                        await HandleUnlinkAsync(basic, unlink, cancellationToken);
                         break;
-#endif
                     default:
                         throw new ProtocolViolationException($"unknown UsbIpCmd {basic.command}");
                 }

--- a/UsbIpServer/ConnectedClient.cs
+++ b/UsbIpServer/ConnectedClient.cs
@@ -15,8 +15,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-using UsbIpServer.Interop;
 using static UsbIpServer.Interop.UsbIp;
+using static UsbIpServer.Interop.VBoxUsb;
 using static UsbIpServer.Tools;
 
 namespace UsbIpServer
@@ -137,7 +137,7 @@ namespace UsbIpServer
 
                     status = Status.ST_DEV_ERR;
                     var cfg = new byte[1] { 0 };
-                    await ClientContext.AttachedDevice.IoControlAsync(VBoxUsb.IoControl.SUPUSB_IOCTL_USB_SET_CONFIG, cfg, null);
+                    await ClientContext.AttachedDevice.IoControlAsync(SUPUSB_IOCTL.USB_SET_CONFIG, cfg, null);
 
                     status = Status.ST_OK;
                     await SendOpCodeAsync(OpCode.OP_REP_IMPORT, Status.ST_OK);

--- a/UsbIpServer/Interop/Linux.cs
+++ b/UsbIpServer/Interop/Linux.cs
@@ -32,6 +32,8 @@ namespace UsbIpServer.Interop
             /// <summary>linux: errno.h</summary>
             EILSEQ = 84,
             /// <summary>linux: errno.h</summary>
+            ECONNRESET = 104,
+            /// <summary>linux: errno.h</summary>
             EREMOTEIO = 121,
         }
     }

--- a/UsbIpServer/Interop/VBoxUsb.cs
+++ b/UsbIpServer/Interop/VBoxUsb.cs
@@ -157,39 +157,30 @@ namespace UsbIpServer.Interop
         /// <summary>VBoxUsb: usblib-win.h</summary>
         public static readonly Guid GUID_CLASS_VBOXUSB = new(0x873fdf, 0xCAFE, 0x80EE, 0xaa, 0x5e, 0x0, 0xc0, 0x4f, 0xb1, 0x72, 0xb);
 
-        public enum IoControl : uint
+        /// <summary>VBoxUsb: usblib-win.h</summary>
+        public enum SUPUSBFLT_IOCTL : uint
         {
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSBFLT_IOCTL_GET_VERSION = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x610 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSBFLT_IOCTL_ADD_FILTER = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x611 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSBFLT_IOCTL_REMOVE_FILTER = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x612 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSBFLT_IOCTL_RUN_FILTERS = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x615 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSBFLT_IOCTL_GET_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x617 << 2) | (Constants.METHOD_BUFFERED),
+            GET_VERSION = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x610 << 2) | (Constants.METHOD_BUFFERED),
+            ADD_FILTER = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x611 << 2) | (Constants.METHOD_BUFFERED),
+            REMOVE_FILTER = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x612 << 2) | (Constants.METHOD_BUFFERED),
+            RUN_FILTERS = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x615 << 2) | (Constants.METHOD_BUFFERED),
+            GET_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x617 << 2) | (Constants.METHOD_BUFFERED),
+        }
 
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_GET_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x603 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_SEND_URB = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x607 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_USB_RESET = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x608 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_USB_SELECT_INTERFACE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x609 << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_USB_SET_CONFIG = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60a << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_USB_CLAIM_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60b << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_USB_RELEASE_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60c << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_IS_OPERATIONAL = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60d << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_USB_CLEAR_ENDPOINT = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60e << 2) | (Constants.METHOD_BUFFERED),
-            /// <summary>VBoxUsb: usblib-win.h</summary>
-            SUPUSB_IOCTL_GET_VERSION = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60f << 2) | (Constants.METHOD_BUFFERED),
+        /// <summary>VBoxUsb: usblib-win.h</summary>
+        public enum SUPUSB_IOCTL : uint
+        {
+            GET_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x603 << 2) | (Constants.METHOD_BUFFERED),
+            SEND_URB = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x607 << 2) | (Constants.METHOD_BUFFERED),
+            USB_RESET = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x608 << 2) | (Constants.METHOD_BUFFERED),
+            USB_SELECT_INTERFACE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x609 << 2) | (Constants.METHOD_BUFFERED),
+            USB_SET_CONFIG = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60a << 2) | (Constants.METHOD_BUFFERED),
+            USB_CLAIM_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60b << 2) | (Constants.METHOD_BUFFERED),
+            USB_RELEASE_DEVICE = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60c << 2) | (Constants.METHOD_BUFFERED),
+            IS_OPERATIONAL = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60d << 2) | (Constants.METHOD_BUFFERED),
+            USB_CLEAR_ENDPOINT = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60e << 2) | (Constants.METHOD_BUFFERED),
+            GET_VERSION = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x60f << 2) | (Constants.METHOD_BUFFERED),
+            USB_ABORT_ENDPOINT = (Constants.FILE_DEVICE_UNKNOWN << 16) | (Constants.FILE_WRITE_ACCESS << 14) | (0x610 << 2) | (Constants.METHOD_BUFFERED),
         }
 
         /// <summary>VBoxUsb: usblib-win.h</summary>

--- a/UsbIpServer/Lock.cs
+++ b/UsbIpServer/Lock.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-FileCopyrightText: 2021 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UsbIpServer
+{
+    sealed class Lock : IDisposable
+    {
+        public static Lock Create(SemaphoreSlim semaphore)
+        {
+            var result = new Lock(semaphore);
+            semaphore.Wait();
+            Interlocked.Exchange(ref result.Locked, 1);
+            return result;
+        }
+
+        public static async Task<Lock> CreateAsync(SemaphoreSlim semaphore, CancellationToken cancellationToken)
+        {
+            var result = new Lock(semaphore);
+            await semaphore.WaitAsync(cancellationToken);
+            Interlocked.Exchange(ref result.Locked, 1);
+            return result;
+        }
+
+        readonly SemaphoreSlim Semaphore;
+        int Locked;
+
+        Lock(SemaphoreSlim semaphore)
+        {
+            Semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.CompareExchange(ref Locked, 0, 1) == 1)
+            {
+                Semaphore.Release();
+            }
+        }
+    }
+}

--- a/UsbIpServer/VBoxUsbMon.cs
+++ b/UsbIpServer/VBoxUsbMon.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Windows.Win32;
 
-using UsbIpServer.Interop;
 using static UsbIpServer.Interop.VBoxUsb;
 using static UsbIpServer.Tools;
 
@@ -23,7 +22,7 @@ namespace UsbIpServer
         public async Task CheckVersion()
         {
             var output = new byte[Marshal.SizeOf<UsbSupVersion>()];
-            await UsbMonitor.IoControlAsync(VBoxUsb.IoControl.SUPUSBFLT_IOCTL_GET_VERSION, null, output);
+            await UsbMonitor.IoControlAsync(SUPUSBFLT_IOCTL.GET_VERSION, null, output);
             BytesToStruct(output, out UsbSupVersion version);
             if ((version.major != USBMON_MAJOR_VERSION) || (version.minor < USBMON_MINOR_VERSION))
             {
@@ -43,7 +42,7 @@ namespace UsbIpServer
             filter.SetMatch(UsbFilterIdx.PORT, UsbFilterMatch.NUM_EXACT, device.BusId.Port);
 
             var output = new byte[Marshal.SizeOf<UsbSupFltAddOut>()];
-            await UsbMonitor.IoControlAsync(VBoxUsb.IoControl.SUPUSBFLT_IOCTL_ADD_FILTER, StructToBytes(filter), output);
+            await UsbMonitor.IoControlAsync(SUPUSBFLT_IOCTL.ADD_FILTER, StructToBytes(filter), output);
             var fltAddOut = BytesToStruct<UsbSupFltAddOut>(output);
             if (fltAddOut.rc != 0 /* VINF_SUCCESS */)
             {
@@ -53,7 +52,7 @@ namespace UsbIpServer
 
         public async Task RunFilters()
         {
-            await UsbMonitor.IoControlAsync(VBoxUsb.IoControl.SUPUSBFLT_IOCTL_RUN_FILTERS, null, null);
+            await UsbMonitor.IoControlAsync(SUPUSBFLT_IOCTL.RUN_FILTERS, null, null);
         }
 
         async Task<DeviceFile> ClaimDeviceOnce(ExportedDevice device)
@@ -74,7 +73,7 @@ namespace UsbIpServer
                 {
                     {
                         var output = new byte[Marshal.SizeOf<UsbSupVersion>()];
-                        await dev.IoControlAsync(VBoxUsb.IoControl.SUPUSB_IOCTL_GET_VERSION, null, output);
+                        await dev.IoControlAsync(SUPUSB_IOCTL.GET_VERSION, null, output);
                         BytesToStruct(output, out UsbSupVersion version);
                         if ((version.major != USBDRV_MAJOR_VERSION) || (version.minor < USBDRV_MINOR_VERSION))
                         {
@@ -82,13 +81,13 @@ namespace UsbIpServer
                         }
                     }
                     {
-                        await dev.IoControlAsync(VBoxUsb.IoControl.SUPUSB_IOCTL_IS_OPERATIONAL, null, null);
+                        await dev.IoControlAsync(SUPUSB_IOCTL.IS_OPERATIONAL, null, null);
                     }
                     IntPtr hdev;
                     {
                         var getDev = new UsbSupGetDev();
                         var output = new byte[Marshal.SizeOf<UsbSupGetDev>()];
-                        await dev.IoControlAsync(VBoxUsb.IoControl.SUPUSB_IOCTL_GET_DEVICE, StructToBytes(getDev), output);
+                        await dev.IoControlAsync(SUPUSB_IOCTL.GET_DEVICE, StructToBytes(getDev), output);
                         BytesToStruct(output, out getDev);
                         hdev = getDev.hDevice;
                     }
@@ -98,13 +97,13 @@ namespace UsbIpServer
                             hDevice = hdev,
                         };
                         var output = new byte[Marshal.SizeOf<UsbSupGetDevMon>()];
-                        await UsbMonitor.IoControlAsync(VBoxUsb.IoControl.SUPUSBFLT_IOCTL_GET_DEVICE, StructToBytes(getDev), output);
+                        await UsbMonitor.IoControlAsync(SUPUSBFLT_IOCTL.GET_DEVICE, StructToBytes(getDev), output);
                         var getDevMon = BytesToStruct<UsbSupGetDevMon>(output);
                     }
                     {
                         var claimDev = new UsbSupClaimDev();
                         var output = new byte[Marshal.SizeOf<UsbSupClaimDev>()];
-                        await dev.IoControlAsync(VBoxUsb.IoControl.SUPUSB_IOCTL_USB_CLAIM_DEVICE, StructToBytes(claimDev), output);
+                        await dev.IoControlAsync(SUPUSB_IOCTL.USB_CLAIM_DEVICE, StructToBytes(claimDev), output);
                         BytesToStruct(output, out claimDev);
                         if (!claimDev.fClaimed)
                         {
@@ -117,7 +116,7 @@ namespace UsbIpServer
                             hDevice = hdev,
                         };
                         var output = new byte[Marshal.SizeOf<UsbSupGetDevMon>()];
-                        await UsbMonitor.IoControlAsync(VBoxUsb.IoControl.SUPUSBFLT_IOCTL_GET_DEVICE, StructToBytes(getDev), output);
+                        await UsbMonitor.IoControlAsync(SUPUSBFLT_IOCTL.GET_DEVICE, StructToBytes(getDev), output);
                         var getDevMon = BytesToStruct<UsbSupGetDevMon>(output);
                     }
                     var result = dev;


### PR DESCRIPTION
As you can see, this is another bit of concurrency complexity.
Unfortunately, the new support also changes the code paths for the bulk endpoints. We need some thorough regression testing before I dare to merge this...