### PR TITLE
ignore duplicated bConfigurationValue

### DIFF
--- a/UsbIpServer/UsbConfigurationDescriptors.cs
+++ b/UsbIpServer/UsbConfigurationDescriptors.cs
@@ -94,7 +94,10 @@ namespace UsbIpServer
                         }
                         BytesToStruct(descriptor[offset..], out USB_CONFIGURATION_DESCRIPTOR config);
                         configuration = new(config);
-                        Configurations.Add(config.bConfigurationValue, configuration);
+                        if (!Configurations.TryAdd(config.bConfigurationValue, configuration))
+                        {
+                            Console.Error.WriteLine($"WARNING: bConfigurationValue {config.bConfigurationValue} is duplicated. ignored.");
+                        }
                         break;
                     case Constants.USB_INTERFACE_DESCRIPTOR_TYPE:
                         if (configuration is null)


### PR DESCRIPTION
Fix #54 

I am not sure if this is an accurate change. However, I believe it is better than the current situation where it crashes.