### PR TITLE
Fix spelling of option --busid

### DIFF
--- a/UnitTests/ParseBindCommand.cs
+++ b/UnitTests/ParseBindCommand.cs
@@ -27,7 +27,7 @@ namespace UnitTests
             mock.Setup(m => m.Bind(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
 
-            Test(ExitCode.Success, mock, "bind", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Success, mock, "bind", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace UnitTests
             mock.Setup(m => m.Bind(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Failure));
 
-            Test(ExitCode.Failure, mock, "bind", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Failure, mock, "bind", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace UnitTests
             mock.Setup(m => m.Bind(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
 
-            Test(ExitCode.Canceled, mock, "bind", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Canceled, mock, "bind", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -65,19 +65,19 @@ namespace UnitTests
         [TestMethod]
         public void BusIdArgumentMissing()
         {
-            Test(ExitCode.ParseError, "bind", "--bus-id");
+            Test(ExitCode.ParseError, "bind", "--busid");
         }
 
         [TestMethod]
         public void BusIdArgumentInvalid()
         {
-            Test(ExitCode.ParseError, "bind", "--bus-id", "not-a-bus-id");
+            Test(ExitCode.ParseError, "bind", "--busid", "not-a-busid");
         }
 
         [TestMethod]
         public void StrayArgument()
         {
-            Test(ExitCode.ParseError, "bind", "--bus-id", TestBusId.ToString(), "stray-argument");
+            Test(ExitCode.ParseError, "bind", "--busid", TestBusId.ToString(), "stray-argument");
         }
     }
 }

--- a/UnitTests/ParseUnbindCommand.cs
+++ b/UnitTests/ParseUnbindCommand.cs
@@ -58,7 +58,7 @@ namespace UnitTests
             mock.Setup(m => m.Unbind(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
 
-            Test(ExitCode.Success, mock, "unbind", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Success, mock, "unbind", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace UnitTests
             mock.Setup(m => m.Unbind(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Failure));
 
-            Test(ExitCode.Failure, mock, "unbind", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Failure, mock, "unbind", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -78,7 +78,7 @@ namespace UnitTests
             mock.Setup(m => m.Unbind(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
 
-            Test(ExitCode.Canceled, mock, "unbind", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Canceled, mock, "unbind", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -126,7 +126,7 @@ namespace UnitTests
         [TestMethod]
         public void AllAndBusId()
         {
-            Test(ExitCode.ParseError, "unbind", "--all", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.ParseError, "unbind", "--all", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -138,13 +138,13 @@ namespace UnitTests
         [TestMethod]
         public void BusIdAndGuid()
         {
-            Test(ExitCode.ParseError, "unbind", "--bus-id", TestBusId.ToString(), "--guid", TestGuid.ToString());
+            Test(ExitCode.ParseError, "unbind", "--busid", TestBusId.ToString(), "--guid", TestGuid.ToString());
         }
 
         [TestMethod]
         public void AllAndBusIdAndGuid()
         {
-            Test(ExitCode.ParseError, "unbind", "--all", "--bus-id", TestBusId.ToString(), "--guid", TestGuid.ToString());
+            Test(ExitCode.ParseError, "unbind", "--all", "--busid", TestBusId.ToString(), "--guid", TestGuid.ToString());
         }
 
         [TestMethod]
@@ -156,7 +156,7 @@ namespace UnitTests
         [TestMethod]
         public void BusIdArgumentMissing()
         {
-            Test(ExitCode.ParseError, "unbind", "--bus-id");
+            Test(ExitCode.ParseError, "unbind", "--busid");
         }
 
         [TestMethod]
@@ -168,7 +168,7 @@ namespace UnitTests
         [TestMethod]
         public void BusIdArgumentInvalid()
         {
-            Test(ExitCode.ParseError, "unbind", "--bus-id", "not-a-bus-id");
+            Test(ExitCode.ParseError, "unbind", "--busid", "not-a-busid");
         }
 
         [TestMethod]
@@ -180,7 +180,7 @@ namespace UnitTests
         [TestMethod]
         public void StrayArgument()
         {
-            Test(ExitCode.ParseError, "unbind", "--bus-id", TestBusId.ToString(), "stray-argument");
+            Test(ExitCode.ParseError, "unbind", "--busid", TestBusId.ToString(), "stray-argument");
         }
     }
 }

--- a/UnitTests/ParseWslAttachCommand.cs
+++ b/UnitTests/ParseWslAttachCommand.cs
@@ -29,7 +29,7 @@ namespace UnitTests
             mock.Setup(m => m.WslAttach(It.Is<BusId>(busId => busId == TestBusId), null, null,
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
 
-            Test(ExitCode.Success, mock, "wsl", "attach", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Success, mock, "wsl", "attach", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -39,7 +39,7 @@ namespace UnitTests
             mock.Setup(m => m.WslAttach(It.Is<BusId>(busId => busId == TestBusId), It.Is<string>(distribution => distribution == TestDistribution), null,
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
 
-            Test(ExitCode.Success, mock, "wsl", "attach", "--bus-id", TestBusId.ToString(), "--distribution", TestDistribution);
+            Test(ExitCode.Success, mock, "wsl", "attach", "--busid", TestBusId.ToString(), "--distribution", TestDistribution);
         }
 
         [TestMethod]
@@ -49,7 +49,7 @@ namespace UnitTests
             mock.Setup(m => m.WslAttach(It.Is<BusId>(busId => busId == TestBusId), null, It.Is<string>(usbipPath => usbipPath == TestUsbipPath),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
 
-            Test(ExitCode.Success, mock, "wsl", "attach", "--bus-id", TestBusId.ToString(), "--usbip-path", TestUsbipPath);
+            Test(ExitCode.Success, mock, "wsl", "attach", "--busid", TestBusId.ToString(), "--usbip-path", TestUsbipPath);
         }
 
         [TestMethod]
@@ -59,7 +59,7 @@ namespace UnitTests
             mock.Setup(m => m.WslAttach(It.Is<BusId>(busId => busId == TestBusId), It.Is<string>(distribution => distribution == TestDistribution), It.Is<string>(usbipPath => usbipPath == TestUsbipPath),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
 
-            Test(ExitCode.Success, mock, "wsl", "attach", "--bus-id", TestBusId.ToString(), "--distribution", TestDistribution, "--usbip-path", TestUsbipPath);
+            Test(ExitCode.Success, mock, "wsl", "attach", "--busid", TestBusId.ToString(), "--distribution", TestDistribution, "--usbip-path", TestUsbipPath);
         }
 
         [TestMethod]
@@ -69,7 +69,7 @@ namespace UnitTests
             mock.Setup(m => m.WslAttach(It.Is<BusId>(busId => busId == TestBusId), null, null,
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Failure));
 
-            Test(ExitCode.Failure, mock, "wsl", "attach", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Failure, mock, "wsl", "attach", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace UnitTests
             mock.Setup(m => m.WslAttach(It.Is<BusId>(busId => busId == TestBusId), null, null,
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
 
-            Test(ExitCode.Canceled, mock, "wsl", "attach", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Canceled, mock, "wsl", "attach", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -97,13 +97,13 @@ namespace UnitTests
         [TestMethod]
         public void BusIdArgumentMissing()
         {
-            Test(ExitCode.ParseError, "wsl", "attach", "--bus-id");
+            Test(ExitCode.ParseError, "wsl", "attach", "--busid");
         }
 
         [TestMethod]
         public void BusIdArgumentInvalid()
         {
-            Test(ExitCode.ParseError, "wsl", "attach", "--bus-id", "not-a-bus-id");
+            Test(ExitCode.ParseError, "wsl", "attach", "--busid", "not-a-busid");
         }
 
         [TestMethod]

--- a/UnitTests/ParseWslDetachCommand.cs
+++ b/UnitTests/ParseWslDetachCommand.cs
@@ -57,7 +57,7 @@ namespace UnitTests
             mock.Setup(m => m.WslDetach(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
 
-            Test(ExitCode.Success, mock, "wsl", "detach", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Success, mock, "wsl", "detach", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -67,7 +67,7 @@ namespace UnitTests
             mock.Setup(m => m.WslDetach(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Failure));
 
-            Test(ExitCode.Failure, mock, "wsl", "detach", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Failure, mock, "wsl", "detach", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -77,7 +77,7 @@ namespace UnitTests
             mock.Setup(m => m.WslDetach(It.Is<BusId>(busId => busId == TestBusId),
                 It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
 
-            Test(ExitCode.Canceled, mock, "wsl", "detach", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.Canceled, mock, "wsl", "detach", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace UnitTests
         [TestMethod]
         public void AllAndBusId()
         {
-            Test(ExitCode.ParseError, "wsl", "detach", "--all", "--bus-id", TestBusId.ToString());
+            Test(ExitCode.ParseError, "wsl", "detach", "--all", "--busid", TestBusId.ToString());
         }
 
         [TestMethod]
@@ -107,19 +107,19 @@ namespace UnitTests
         [TestMethod]
         public void BusIdArgumentMissing()
         {
-            Test(ExitCode.ParseError, "wsl", "detach", "--bus-id");
+            Test(ExitCode.ParseError, "wsl", "detach", "--busid");
         }
 
         [TestMethod]
         public void BusIdArgumentInvalid()
         {
-            Test(ExitCode.ParseError, "wsl", "detach", "--bus-id", "not-a-bus-id");
+            Test(ExitCode.ParseError, "wsl", "detach", "--busid", "not-a-busid");
         }
 
         [TestMethod]
         public void StrayArgument()
         {
-            Test(ExitCode.ParseError, "wsl", "detach", "--bus-id", TestBusId.ToString(), "stray-argument");
+            Test(ExitCode.ParseError, "wsl", "detach", "--busid", TestBusId.ToString(), "stray-argument");
         }
     }
 }

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -97,10 +97,10 @@ namespace UsbIpServer
 
             {
                 //
-                //  bind --bus-id <BUSID>
+                //  bind --busid <BUSID>
                 //
                 var busIdOption = new Option<BusId>(
-                    aliases: new[] { "--bus-id", "-b" },
+                    aliases: new[] { "--busid", "-b" },
                     parseArgument: ParseBusId
                 )
                 {
@@ -197,10 +197,10 @@ namespace UsbIpServer
                     Description = "Stop sharing all devices",
                 };
                 //
-                //  unbind [--bus-id <BUSID>]
+                //  unbind [--busid <BUSID>]
                 //
                 var busIdOption = new Option<BusId>(
-                    aliases: new[] { "--bus-id", "-b" },
+                    aliases: new[] { "--busid", "-b" },
                     parseArgument: ParseBusId
                 )
                 {
@@ -278,10 +278,10 @@ namespace UsbIpServer
                 rootCommand.AddCommand(wslCommand);
                 {
                     //
-                    //  wsl attach --bus-id <BUSID>
+                    //  wsl attach --busid <BUSID>
                     //
                     var busIdOption = new Option<BusId>(
-                        aliases: new[] { "--bus-id", "-b" },
+                        aliases: new[] { "--busid", "-b" },
                         parseArgument: ParseBusId
                     )
                     {
@@ -345,10 +345,10 @@ namespace UsbIpServer
                         Description = "Detach all devices",
                     };
                     //
-                    //  wsl detach [--bus-id <BUSID>]
+                    //  wsl detach [--busid <BUSID>]
                     //
                     var busIdOption = new Option<BusId>(
-                        aliases: new[] { "--bus-id", "-b" },
+                        aliases: new[] { "--busid", "-b" },
                         parseArgument: ParseBusId
                     )
                     {


### PR DESCRIPTION
All releases use --busid, refactoring spelled it as --bus-id by mistake.