### PR TITLE
Remove obsolete Microsoft.Win32.Registry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@ SPDX-License-Identifier: GPL-2.0-only
 
     <!-- UsbIpServer -->
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.1.635-beta" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta3.22111.2" />
 

--- a/UsbIpServer/UsbIpServer.csproj
+++ b/UsbIpServer/UsbIpServer.csproj
@@ -55,7 +55,6 @@ SPDX-License-Identifier: GPL-2.0-only
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
-    <PackageReference Include="Microsoft.Win32.Registry" />
     <PackageReference Include="Microsoft.Windows.CsWin32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Was a left-over from the .NET 5 to .NET 6 migration