### PR TITLE
Add PowerShell cmdlets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,7 @@ charset = utf-8-bom
 [*.md]
 insert_final_newline = true
 trim_trailing_whitespace = true
-[*.csproj]
+[*.{csproj,props,wixproj}]
 indent_size = 2
 [*.yml]
 indent_size = 2
@@ -72,10 +72,16 @@ dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
 # Use PascalCase for constant fields  
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+end_of_line = crlf
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
 ###############################
 # C# Coding Conventions       #
 ###############################
@@ -135,6 +141,11 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
 ###############################
 # VB Coding Conventions       #
 ###############################

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,9 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore UsbIpServer
+      run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --configuration Release --no-restore --verbosity normal --collect:"XPlat Code Coverage"
+      run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0
       with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2021 Frans van Dorsselaer
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+<Project>
+  
+  <!-- Sane defaults; override in project where needed -->
+
+  <PropertyGroup>
+    <!-- This product only supports x64 (the only architecture supported by VBoxUsb) -->
+    <Platforms>x64</Platforms>
+    <Platform>x64</Platform>
+
+    <!-- Use the latest .NET SDK -->
+    <!-- This product requires Windows 8 or higher -->
+    <TargetFramework>net6.0-windows8.0</TargetFramework>
+    
+    <!-- Use the latest C# language standard -->
+    <LangVersion>10.0</LangVersion>
+    
+    <!-- Be very strict -->
+    <WarningLevel>5</WarningLevel>
+    <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-all</AnalysisLevel>
+    <!-- NOTE: disabled, see: https://github.com/dotnet/linker/issues/2622 -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+
+    <!-- Common defaults -->
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <SelfContained>false</SelfContained>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <IsTrimmable>true</IsTrimmable>
+
+    <Product>usbipd-win</Product>
+    <Company>Frans van Dorsselaer</Company>
+    <Copyright>Copyright (C) $([System.DateTime]::UtcNow.ToString("yyyy"))  $(Company)</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersion.MsBuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,8 +25,7 @@ SPDX-License-Identifier: GPL-2.0-only
     <Nullable>enable</Nullable>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-all</AnalysisLevel>
-    <!-- NOTE: disabled, see: https://github.com/dotnet/linker/issues/2622 -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- Common defaults -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,10 @@ SPDX-License-Identifier: GPL-2.0-only
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.1.635-beta" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
 
+    <!-- Usbipd.PowerShell -->
+    <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.0" />
+
     <!-- Installer -->
     <PackageVersion Include="WiX" Version="3.11.2" />
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@ SPDX-License-Identifier: GPL-2.0-only
 
     <!-- Usbipd.PowerShell -->
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.0" />
+    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
 
     <!-- Installer -->
     <PackageVersion Include="WiX" Version="3.11.2" />

--- a/Installer/Installer.wixproj
+++ b/Installer/Installer.wixproj
@@ -23,19 +23,20 @@ SPDX-License-Identifier: GPL-2.0-only
     <OutputName>usbipd-win</OutputName>
     <DefineSolutionProperties>false</DefineSolutionProperties>
     <PublishDir>..\UsbIpServer\bin\publish</PublishDir>
+    <PowerShellDir>..\Usbipd.PowerShell\bin\$(Configuration)\netstandard2.0\win</PowerShellDir>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
-    <DefineConstants>Debug;PublishDir=$(PublishDir);DriversDir=$(ProjectDir)..\Drivers;Year=$([System.DateTime]::UtcNow.ToString("yyyy"))</DefineConstants>
+    <DefineConstants>Debug;PublishDir=$(PublishDir);PowerShellDir=$(PowerShellDir);DriversDir=$(ProjectDir)..\Drivers;Year=$([System.DateTime]::UtcNow.ToString("yyyy"))</DefineConstants>
     <Cultures>en-US</Cultures>
     <SuppressAllWarnings>False</SuppressAllWarnings>
     <Pedantic>True</Pedantic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
-    <DefineConstants>PublishDir=$(PublishDir);DriversDir=$(ProjectDir)..\Drivers;Year=$([System.DateTime]::UtcNow.ToString("yyyy"))</DefineConstants>
+    <DefineConstants>PublishDir=$(PublishDir);PowerShellDir=$(PowerShellDir);DriversDir=$(ProjectDir)..\Drivers;Year=$([System.DateTime]::UtcNow.ToString("yyyy"))</DefineConstants>
     <Cultures>en-US</Cultures>
     <SuppressAllWarnings>False</SuppressAllWarnings>
     <Pedantic>True</Pedantic>
@@ -55,6 +56,14 @@ SPDX-License-Identifier: GPL-2.0-only
       <ComponentGroupName>UsbIpServer</ComponentGroupName>
       <PreprocessorVariable>var.PublishDir</PreprocessorVariable>
       <Transforms>HarvestTransform.xslt</Transforms>
+    </HarvestDirectory>
+    <HarvestDirectory Include="$(PowerShellDir)" Visible="false">
+      <DirectoryRefId>PowerShell</DirectoryRefId>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+      <SuppressCOM>true</SuppressCOM>
+      <SuppressRegistry>true</SuppressRegistry>
+      <ComponentGroupName>PowerShell</ComponentGroupName>
+      <PreprocessorVariable>var.PowerShellDir</PreprocessorVariable>
     </HarvestDirectory>
   </ItemGroup>
   <ItemGroup>

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -98,6 +98,17 @@ SPDX-License-Identifier: GPL-2.0-only
                 >
                 <ComponentGroupRef Id="Drivers" />
             </Feature>
+            <Feature
+                Id="PowerShell"
+                Level="1"
+                AllowAdvertise="no"
+                Display="expand"
+                Absent="disallow"
+                Title="PowerShell Support"
+                Description="A loadable module for PowerShell."
+                >
+                <ComponentGroupRef Id="PowerShell" />
+            </Feature>
         </Feature>
 
         <UIRef Id="UserInterface"/>
@@ -106,7 +117,9 @@ SPDX-License-Identifier: GPL-2.0-only
     <Fragment>
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
-                <Directory Id="APPLICATIONFOLDER" Name="usbipd-win" FileSource="$(var.PublishDir)" />
+                <Directory Id="APPLICATIONFOLDER" Name="usbipd-win" FileSource="$(var.PublishDir)">
+                    <Directory Id="PowerShell" Name="PowerShell" FileSource="$(var.PowerShellDir)" />
+                </Directory>
             </Directory>
         </Directory>
     </Fragment>

--- a/InstallerDependencies/InstallerDependencies.csproj
+++ b/InstallerDependencies/InstallerDependencies.csproj
@@ -7,20 +7,16 @@ SPDX-License-Identifier: GPL-2.0-only
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows8.0</TargetFrameworks>
-    <Platforms>x64</Platforms>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- This project is not really C#, so disable all analyzers. -->
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <IsTrimmable>false</IsTrimmable>
     <!-- This project is not really C#, so prevent creating any .cs files. -->
     <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="WiX" />
   </ItemGroup>
 

--- a/NetStandard.props
+++ b/NetStandard.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2021 Frans van Dorsselaer
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+<Project>
+  
+  <PropertyGroup>
+    <Platforms>AnyCPU</Platforms>
+    <Platform>AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/UnitTests/Automation_Tests.cs
+++ b/UnitTests/Automation_Tests.cs
@@ -1,0 +1,152 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Usbipd.Automation;
+using UsbIpServer;
+
+namespace UnitTests
+{
+    [TestClass]
+    sealed class Automation_Tests
+    {
+        [TestMethod]
+        public void State_Constructor()
+        {
+            _ = new State();
+        }
+
+        [TestMethod]
+        public void State_Devices()
+        {
+            var state = new State()
+            {
+                Devices = new Device[]
+                {
+                    new(),
+                    new(),
+                },
+            };
+            Assert.AreEqual(2, state.Devices.Count);
+        }
+
+        [TestMethod]
+        public void Device_Constructor()
+        {
+            var device = new Device();
+            Assert.AreEqual(string.Empty, device.InstanceId);
+            Assert.AreEqual(string.Empty, device.Description);
+            Assert.IsFalse(device.IsForced);
+            Assert.IsNull(device.BusId);
+            Assert.IsNull(device.PersistedGuid);
+            Assert.IsNull(device.StubInstanceId);
+            Assert.IsNull(device.ClientIPAddress);
+            Assert.IsNull(device.ClientWslInstance);
+            Assert.IsFalse(device.IsBound);
+            Assert.IsFalse(device.IsConnected);
+            Assert.IsFalse(device.IsAttached);
+            Assert.IsFalse(device.IsWslAttached);
+        }
+
+        [TestMethod]
+        public void Device_InstanceId()
+        {
+            const string testInstanceId = "testInstanceId";
+
+            var device = new Device()
+            {
+                InstanceId = testInstanceId,
+            };
+            Assert.AreEqual(testInstanceId, device.InstanceId);
+        }
+
+        [TestMethod]
+        public void Device_Description()
+        {
+            const string testDescription = "testDescription";
+
+            var device = new Device()
+            {
+                Description = testDescription,
+            };
+            Assert.AreEqual(testDescription, device.Description);
+        }
+
+        [TestMethod]
+        public void Device_IsForced()
+        {
+            var device = new Device()
+            {
+                IsForced = true,
+            };
+            Assert.IsTrue(device.IsForced);
+        }
+
+        [TestMethod]
+        public void Device_BusId()
+        {
+            var testBusId = new BusId() { Bus = 1, Port = 42 };
+
+            var device = new Device()
+            {
+                BusId = testBusId.ToString(),
+            };
+            Assert.AreEqual(testBusId.ToString(), device.BusId);
+            Assert.IsTrue(device.IsConnected);
+        }
+
+        [TestMethod]
+        public void Device_PeristedGuid()
+        {
+            var testPersistedGuid = Guid.NewGuid();
+
+            var device = new Device()
+            {
+                PersistedGuid = testPersistedGuid,
+            };
+            Assert.AreEqual(testPersistedGuid, device.PersistedGuid);
+            Assert.IsTrue(device.IsBound);
+        }
+
+        [TestMethod]
+        public void Device_StubInstanceId()
+        {
+            const string testStubInstanceId = "testStubInstanceId";
+
+            var device = new Device()
+            {
+                StubInstanceId = testStubInstanceId,
+            };
+            Assert.AreEqual(testStubInstanceId, device.StubInstanceId);
+        }
+
+        [TestMethod]
+        public void Device_ClientIPAddress()
+        {
+            var testClientIPAddress = IPAddress.Parse("1.2.3.4");
+
+            var device = new Device()
+            {
+                ClientIPAddress = testClientIPAddress,
+            };
+            Assert.AreEqual(testClientIPAddress, device.ClientIPAddress);
+            Assert.IsTrue(device.IsAttached);
+        }
+
+        [TestMethod]
+        public void Device_ClientWslInstance()
+        {
+            var testClientWslInstance = "testClientWslInstance";
+
+            var device = new Device()
+            {
+                ClientWslInstance = testClientWslInstance,
+            };
+            Assert.AreEqual(testClientWslInstance, device.ClientWslInstance);
+            Assert.IsTrue(device.IsWslAttached);
+        }
+    }
+}

--- a/UnitTests/Parse_state_Tests.cs
+++ b/UnitTests/Parse_state_Tests.cs
@@ -1,0 +1,63 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
+using System.CommandLine;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using UsbIpServer;
+
+namespace UnitTests
+{
+    using ExitCode = Program.ExitCode;
+
+    [TestClass]
+    sealed class Parse_state_Tests
+        : ParseTestBase
+    {
+        [TestMethod]
+        public void Success()
+        {
+            var mock = CreateMock();
+            mock.Setup(m => m.State(
+                It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Success));
+
+            Test(ExitCode.Success, mock, "state");
+        }
+
+        [TestMethod]
+        public void Failure()
+        {
+            var mock = CreateMock();
+            mock.Setup(m => m.State(
+                It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(ExitCode.Failure));
+
+            Test(ExitCode.Failure, mock, "state");
+        }
+
+        [TestMethod]
+        public void Canceled()
+        {
+            var mock = CreateMock();
+            mock.Setup(m => m.State(
+                It.IsNotNull<IConsole>(), It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
+
+            Test(ExitCode.Canceled, mock, "state");
+        }
+
+        [TestMethod]
+        public void Help()
+        {
+            Test(ExitCode.Success, "state", "--help");
+        }
+
+        [TestMethod]
+        public void StrayArgument()
+        {
+            Test(ExitCode.ParseError, "state", "stray-argument");
+        }
+    }
+}

--- a/UnitTests/Program_Tests.cs
+++ b/UnitTests/Program_Tests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.CommandLine;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -60,6 +61,13 @@ namespace UnitTests
                 Test(ExitCode.Success, mock, "license");
             });
             Assert.IsInstanceOfType(exception.InnerException, typeof(NotImplementedException));
+        }
+
+        [TestMethod]
+        public void CompletionGuard_DoesNotThrow()
+        {
+            var completions = Program.CompletionGuard(null!, null!);
+            Assert.IsTrue(completions.SequenceEqual(Array.Empty<string>()));
         }
     }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -7,22 +7,7 @@ SPDX-License-Identifier: GPL-2.0-only
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows8.0</TargetFramework>
-    <Platforms>x64</Platforms>
-    <Platform>x64</Platform>
-
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>enable</Nullable>
-
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-
-    <InvariantGlobalization>true</InvariantGlobalization>
-
-    <IsPackable>false</IsPackable>
-
   </PropertyGroup>
 
   <ItemGroup>

--- a/UsbIpServer/CommandHandlers.cs
+++ b/UsbIpServer/CommandHandlers.cs
@@ -594,6 +594,8 @@ namespace UsbIpServer
             Justification = "Only basic types are used; all required members are accessed (and therefore not trimmed away).")]
         async Task<ExitCode> ICommandHandlers.State(IConsole console, CancellationToken cancellationToken)
         {
+            Console.SetError(TextWriter.Null);
+
             WslDistributions? distros = null;
             try
             {

--- a/UsbIpServer/CommandHandlers.cs
+++ b/UsbIpServer/CommandHandlers.cs
@@ -7,7 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Runtime.Serialization.Json;
 using System.Security.Principal;
 using System.Text;
 using System.Threading;
@@ -19,6 +23,7 @@ using Microsoft.Extensions.Hosting.WindowsServices;
 using Microsoft.Extensions.Logging;
 using Windows.Win32.Security;
 using static UsbIpServer.ConsoleTools;
+using Automation = Usbipd.Automation;
 using ExitCode = UsbIpServer.Program.ExitCode;
 
 namespace UsbIpServer
@@ -37,6 +42,8 @@ namespace UsbIpServer
         public Task<ExitCode> WslDetach(BusId busId, IConsole console, CancellationToken cancellationToken);
         public Task<ExitCode> WslDetachAll(IConsole console, CancellationToken cancellationToken);
         public Task<ExitCode> WslList(IConsole console, CancellationToken cancellationToken);
+
+        public Task<ExitCode> State(IConsole console, CancellationToken cancellationToken);
     }
 
     sealed class CommandHandlers : ICommandHandlers
@@ -582,6 +589,30 @@ namespace UsbIpServer
             console.ReportIfServerNotRunning();
             console.ReportIfForceNeeded();
             return ExitCode.Success;
+        }
+
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = "Only basic types are used; all required members are accessed (and therefore not trimmed away).")]
+        Task<ExitCode> ICommandHandlers.State(IConsole console, CancellationToken cancellationToken)
+        {
+            var state = new Automation.State()
+            {
+                Devices = new[]
+                {
+                    new Automation.Device() { Name = "些字", IPAddress = IPAddress.Parse("1.2.3.4"), },
+                    new Automation.Device() { Name = "etc" },
+                }
+            };
+
+            using var memoryStream = new MemoryStream();
+            {
+                using var writer = JsonReaderWriterFactory.CreateJsonWriter(memoryStream, Encoding.UTF8, false, true);
+                var serializer = new DataContractJsonSerializer(state.GetType());
+                serializer.WriteObject(writer, state);
+            }
+
+            Console.Write(Encoding.UTF8.GetString(memoryStream.ToArray()));
+            return Task.FromResult(ExitCode.Success);
         }
     }
 }

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -229,6 +229,21 @@ namespace UsbIpServer
             }
             {
                 //
+                //  state
+                //
+                var stateCommand = new Command("state", "Output state in JSON\0"
+                    + "Outputs the current state of all USB devices in machine-readable JSON suitable for scripted automation.");
+                stateCommand.SetHandler(async (InvocationContext invocationContext) =>
+                {
+                    invocationContext.ExitCode = (int)(
+                        await commandHandlers.State(
+                            invocationContext.Console, invocationContext.GetCancellationToken())
+                        );
+                });
+                rootCommand.AddCommand(stateCommand);
+            }
+            {
+                //
                 //  unbind [--all]
                 //
                 var allOption = new Option(

--- a/UsbIpServer/Program.cs
+++ b/UsbIpServer/Program.cs
@@ -83,7 +83,7 @@ namespace UsbIpServer
             }
         }
 
-        static IEnumerable<string> CompletionGuard(CompletionContext completionContext, Func<IEnumerable<string>?> complete)
+        internal static IEnumerable<string> CompletionGuard(CompletionContext completionContext, Func<IEnumerable<string>?> complete)
         {
             try
             {

--- a/UsbIpServer/UsbIpServer.csproj
+++ b/UsbIpServer/UsbIpServer.csproj
@@ -17,6 +17,9 @@ SPDX-License-Identifier: GPL-2.0-only
     <PublishProfile>Properties\PublishProfiles\InputForInstaller.pubxml</PublishProfile>
 
     <AssemblyName>usbipd</AssemblyName>
+
+    <!-- NOTE: see: https://github.com/dotnet/linker/issues/2622 -->
+    <NoWarn>AD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UsbIpServer/UsbIpServer.csproj
+++ b/UsbIpServer/UsbIpServer.csproj
@@ -20,10 +20,6 @@ SPDX-License-Identifier: GPL-2.0-only
   </PropertyGroup>
 
   <ItemGroup>
-    <TrimmableAssembly Include="System.CommandLine" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="..\COPYING.md" Link="COPYING.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/UsbIpServer/UsbIpServer.csproj
+++ b/UsbIpServer/UsbIpServer.csproj
@@ -8,37 +8,15 @@ SPDX-License-Identifier: GPL-2.0-only
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Platforms>x64</Platforms>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-
-    <!-- defaults (used by: dotnet build) -->
-    <TargetFramework>net6.0-windows8.0</TargetFramework>
-    <Platform>x64</Platform>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <SelfContained>false</SelfContained>
-
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>enable</Nullable>
 
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-
-    <Product>usbipd-win</Product>
-    <Company>Frans van Dorsselaer</Company>
-    <Copyright>Copyright (C) $([System.DateTime]::UtcNow.ToString("yyyy"))  $(Company)</Copyright>
-
-    <!-- generate info, but exclude the stuff that is set by GitVersion -->
-    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
-
+    <IsPublishable>true</IsPublishable>
     <PublishProfile>Properties\PublishProfiles\InputForInstaller.pubxml</PublishProfile>
 
     <AssemblyName>usbipd</AssemblyName>
-    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,16 +28,16 @@ SPDX-License-Identifier: GPL-2.0-only
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="Microsoft.Windows.CsWin32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Usbipd.Automation\Usbipd.Automation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Usbipd.Automation/Device.cs
+++ b/Usbipd.Automation/Device.cs
@@ -32,29 +32,24 @@ namespace Usbipd.Automation
         /// <summary>
         /// Serialization for <see cref="IPAddress"/>.
         /// </summary>
-        [DataMember(Name = nameof(IPAddress))]
-        string? _IPAddress;
+        [DataMember(Name = nameof(ClientIPAddress))]
+        string? _ClientIPAddress;
 
-        [IgnoreDataMember]
         public IPAddress? ClientIPAddress
         {
-            get => IPAddress.TryParse(_IPAddress, out var ipAddress) ? ipAddress : null;
-            init => _IPAddress = value?.ToString();
+            get => IPAddress.TryParse(_ClientIPAddress, out var clientIPAddress) ? clientIPAddress : null;
+            init => _ClientIPAddress = value?.ToString();
         }
 
         [DataMember]
         public string? ClientWslInstance { get; init; }
 
-        [IgnoreDataMember]
         public bool IsBound { get => PersistedGuid is not null; }
 
-        [IgnoreDataMember]
         public bool IsConnected { get => BusId is not null; }
 
-        [IgnoreDataMember]
         public bool IsAttached { get => ClientIPAddress is not null; }
 
-        [IgnoreDataMember]
         public bool IsWslAttached { get => ClientWslInstance is not null; }
     }
 }

--- a/Usbipd.Automation/Device.cs
+++ b/Usbipd.Automation/Device.cs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+using System;
 using System.Net;
 using System.Runtime.Serialization;
 
@@ -11,7 +12,22 @@ namespace Usbipd.Automation
     public sealed class Device
     {
         [DataMember]
-        public string Name { get; init; } = string.Empty;
+        public string InstanceId { get; init; } = string.Empty;
+
+        [DataMember]
+        public string Description { get; init; } = string.Empty;
+
+        [DataMember]
+        public bool IsForced { get; init; }
+
+        [DataMember]
+        public string? BusId { get; init; }
+
+        [DataMember]
+        public Guid? PersistedGuid { get; init; }
+
+        [DataMember]
+        public string? StubInstanceId { get; init; }
 
         /// <summary>
         /// Serialization for <see cref="IPAddress"/>.
@@ -20,10 +36,25 @@ namespace Usbipd.Automation
         string? _IPAddress;
 
         [IgnoreDataMember]
-        public IPAddress? IPAddress
+        public IPAddress? ClientIPAddress
         {
             get => IPAddress.TryParse(_IPAddress, out var ipAddress) ? ipAddress : null;
             init => _IPAddress = value?.ToString();
         }
+
+        [DataMember]
+        public string? ClientWslInstance { get; init; }
+
+        [IgnoreDataMember]
+        public bool IsBound { get => PersistedGuid is not null; }
+
+        [IgnoreDataMember]
+        public bool IsConnected { get => BusId is not null; }
+
+        [IgnoreDataMember]
+        public bool IsAttached { get => ClientIPAddress is not null; }
+
+        [IgnoreDataMember]
+        public bool IsWslAttached { get => ClientWslInstance is not null; }
     }
 }

--- a/Usbipd.Automation/Device.cs
+++ b/Usbipd.Automation/Device.cs
@@ -1,0 +1,29 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace Usbipd.Automation
+{
+    [DataContract]
+    public sealed class Device
+    {
+        [DataMember]
+        public string Name { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Serialization for <see cref="IPAddress"/>.
+        /// </summary>
+        [DataMember(Name = nameof(IPAddress))]
+        string? _IPAddress;
+
+        [IgnoreDataMember]
+        public IPAddress? IPAddress
+        {
+            get => IPAddress.TryParse(_IPAddress, out var ipAddress) ? ipAddress : null;
+            init => _IPAddress = value?.ToString();
+        }
+    }
+}

--- a/Usbipd.Automation/IsExternalInit.cs
+++ b/Usbipd.Automation/IsExternalInit.cs
@@ -1,0 +1,13 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Fix for using C# 9 feature in netstandard2.0.
+    /// </summary>
+    static class IsExternalInit
+    {
+    }
+}

--- a/Usbipd.Automation/State.cs
+++ b/Usbipd.Automation/State.cs
@@ -1,0 +1,28 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+[assembly: CLSCompliant(false)]
+
+namespace Usbipd.Automation
+{
+    [DataContract]
+    public sealed class State
+    {
+        /// <summary>
+        /// Serialization for <see cref="Devices" />.
+        /// </summary>
+        [DataMember(Name = nameof(Devices))]
+        List<Device> _Devices = new();
+
+        public IReadOnlyCollection<Device> Devices
+        {
+            get => _Devices.AsReadOnly();
+            init => _Devices = new(value);
+        }
+    }
+}

--- a/Usbipd.Automation/Usbipd.Automation.csproj
+++ b/Usbipd.Automation/Usbipd.Automation.csproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\NetStandard.props" />
+
+</Project>

--- a/Usbipd.PowerShell/GetUsbipdDevice.cs
+++ b/Usbipd.PowerShell/GetUsbipdDevice.cs
@@ -1,0 +1,80 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System.Diagnostics;
+using System.IO;
+using System.Management.Automation;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System.Threading.Tasks;
+using Usbipd.Automation;
+
+namespace Usbipd.PowerShell
+{
+    [Cmdlet(VerbsCommon.Get, "UsbipdDevice")]
+    [OutputType(typeof(Device))]
+    public class GetUsbipdDeviceCommand : Cmdlet
+    {
+        State State = new();
+
+        protected override void BeginProcessing()
+        {
+            WriteDebug($"Detected installation path: {Installation.ExePath}");
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = Installation.ExePath,
+                UseShellExecute = false,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                Arguments = "state",
+            };
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                throw new ApplicationFailedException($"Cannot execute '{Installation.ExePath}'.");
+            }
+
+            var stdout = string.Empty;
+            var stderr = string.Empty;
+
+            var captureTasks = new[]
+            {
+                Task.Run(async () => { stdout = await process.StandardOutput.ReadToEndAsync(); }),
+                Task.Run(async () => { stderr = await process.StandardError.ReadToEndAsync(); }),
+            };
+
+            process.WaitForExit();
+            Task.WhenAll(captureTasks).Wait();
+
+            if (process.ExitCode != 0)
+            {
+                throw new ApplicationFailedException($"usbipd failed with exit code {process.ExitCode}.");
+            }
+            if (!string.IsNullOrEmpty(stderr))
+            {
+                throw new ApplicationFailedException($"usbipd returned unexpected error text:\n\n{stderr}");
+            }
+
+            WriteDebug(stdout);
+
+            var serializer = new DataContractJsonSerializer(typeof(State));
+            using var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(stdout));
+            State = (State)serializer.ReadObject(memoryStream);
+        }
+
+        protected override void ProcessRecord()
+        {
+            foreach (var d in State.Devices)
+            {
+                WriteObject(d);
+            }
+        }
+    }
+}

--- a/Usbipd.PowerShell/GlobalSuppressions.cs
+++ b/Usbipd.PowerShell/GlobalSuppressions.cs
@@ -1,0 +1,12 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "there is never a synchronization context")]

--- a/Usbipd.PowerShell/Installation.cs
+++ b/Usbipd.PowerShell/Installation.cs
@@ -1,0 +1,43 @@
+﻿// SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+using System;
+using System.IO;
+using System.Management.Automation;
+using Microsoft.Win32;
+
+[assembly: CLSCompliant(false)]
+
+namespace Usbipd.PowerShell
+{
+    static class Installation
+    {
+        public static string ExePath
+        {
+            get
+            {
+                // NOTE: User may be running 32-bit PowerShell, so we must excplicitly ask for 64-bit registry.
+                using var root = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+
+                string exeFile;
+                if (root.OpenSubKey(@"SOFTWARE\usbipd-win") is not RegistryKey key
+                    || key.GetValue("APPLICATIONFOLDER") is not string applicationFolder
+                    || !Version.TryParse(key.GetValue("Version") as string, out var version)
+                    || !File.Exists(exeFile = Path.Combine(Path.GetFullPath(applicationFolder), "usbipd.exe")))
+                {
+                    throw new ApplicationFailedException("usbipd-win is not installed.");
+                }
+                if (version != Version.Parse(GitVersionInformation.MajorMinorPatch))
+                {
+                    throw new ApplicationFailedException($"PowerShell module version {GitVersionInformation.MajorMinorPatch} does not match installed usbipd-win version {version}.");
+                }
+#if DEBUG
+                return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetCallingAssembly().Location), @"..\..\..\..\..\UsbIpServer\bin\x64\Debug\net6.0-windows8.0\win-x64\usbipd.exe"));
+#else
+                return exeFile;
+#endif
+            }
+        }
+    }
+}

--- a/Usbipd.PowerShell/Usbipd.PowerShell.csproj
+++ b/Usbipd.PowerShell/Usbipd.PowerShell.csproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\NetStandard.props" />
+  
+  <PropertyGroup>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(PkgMicrosoft_Win32_Registry)\runtimes\$(RuntimeIdentifier)\lib\$(TargetFramework)\Microsoft.Win32.Registry.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" GeneratePathProperty="true" />
+    <PackageReference Include="PowerShellStandard.Library">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Usbipd.Automation\Usbipd.Automation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/usbipd-win.sln
+++ b/usbipd-win.sln
@@ -13,9 +13,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		codecov.yml = codecov.yml
 		COPYING.md = COPYING.md
+		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		GitVersion.yml = GitVersion.yml
 		global.json = global.json
+		NetStandard.props = NetStandard.props
 		nuget.config = nuget.config
 		README.md = README.md
 		SECURITY.md = SECURITY.md
@@ -25,11 +27,16 @@ Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "Installer", "Installer\Inst
 	ProjectSection(ProjectDependencies) = postProject
 		{00B55725-8FBA-40C0-A691-312935717AF3} = {00B55725-8FBA-40C0-A691-312935717AF3}
 		{5CE75792-6F4F-4B16-83E6-29052C6E0D8D} = {5CE75792-6F4F-4B16-83E6-29052C6E0D8D}
+		{3C3ED2C8-54D0-48D4-8BF4-78220D4A9E20} = {3C3ED2C8-54D0-48D4-8BF4-78220D4A9E20}
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InstallerDependencies", "InstallerDependencies\InstallerDependencies.csproj", "{00B55725-8FBA-40C0-A691-312935717AF3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTests", "UnitTests\UnitTests.csproj", "{03DA15B4-7F40-4EF3-814B-9050C7A671B5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Usbipd.PowerShell", "Usbipd.PowerShell\Usbipd.PowerShell.csproj", "{3C3ED2C8-54D0-48D4-8BF4-78220D4A9E20}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Usbipd.Automation", "Usbipd.Automation\Usbipd.Automation.csproj", "{934A2FBC-4EEB-4CE7-88A4-E3336E89DAEB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +58,14 @@ Global
 		{03DA15B4-7F40-4EF3-814B-9050C7A671B5}.Debug|x64.Build.0 = Debug|x64
 		{03DA15B4-7F40-4EF3-814B-9050C7A671B5}.Release|x64.ActiveCfg = Release|x64
 		{03DA15B4-7F40-4EF3-814B-9050C7A671B5}.Release|x64.Build.0 = Release|x64
+		{3C3ED2C8-54D0-48D4-8BF4-78220D4A9E20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C3ED2C8-54D0-48D4-8BF4-78220D4A9E20}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C3ED2C8-54D0-48D4-8BF4-78220D4A9E20}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C3ED2C8-54D0-48D4-8BF4-78220D4A9E20}.Release|x64.Build.0 = Release|Any CPU
+		{934A2FBC-4EEB-4CE7-88A4-E3336E89DAEB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{934A2FBC-4EEB-4CE7-88A4-E3336E89DAEB}.Debug|x64.Build.0 = Debug|Any CPU
+		{934A2FBC-4EEB-4CE7-88A4-E3336E89DAEB}.Release|x64.ActiveCfg = Release|Any CPU
+		{934A2FBC-4EEB-4CE7-88A4-E3336E89DAEB}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds helpers for scripted automation:

1. There is a new command `usbipd state`, which returns JSON for all USB devices. More easily parsed by scripts than the standard `list` output, with more information and without truncating long strings.
2. There is a PowerShell module that exposes a `Get-UsbipdDevice` cmdlet that uses the JSON from (1) and returns it as PowerShell objects, with even more (meta-)information like `IsConnected`, `IsAttached`, etc.

The PowerShell cmdlet is built on top of PowerShellStandard, so it can be used by standard Windows 10 PowerShell 5.1 (either x64 or x86) as well as PowerShell 7 from the store. For now, I do not intend to publish the PowerShell module to PowerShell Gallery, as the version is tightly coupled to the version of usbipd-win. You will have to load the module manually with:

```
Import-Module 'C:\Program Files\usbipd-win\PowerShell\Usbipd.Powershell.dll'
```

Fixes #280