### PR TITLE
support wsl2 bridged mode

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,7 @@ SPDX-License-Identifier: GPL-2.0-only
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.63-beta" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Ini">
-      <Version>6.0.0</Version>
-    </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
 
     <!-- Usbipd.PowerShell -->
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,9 @@ SPDX-License-Identifier: GPL-2.0-only
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.63-beta" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Ini">
+      <Version>6.0.0</Version>
+    </PackageVersion>
 
     <!-- Usbipd.PowerShell -->
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/Usbipd/Usbipd.csproj
+++ b/Usbipd/Usbipd.csproj
@@ -24,6 +24,7 @@ SPDX-License-Identifier: GPL-2.0-only
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="Microsoft.Windows.CsWin32">
       <PrivateAssets>all</PrivateAssets>

--- a/Usbipd/WslDistributions.cs
+++ b/Usbipd/WslDistributions.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: Microsoft Corporation
 // SPDX-FileCopyrightText: 2021 Frans van Dorsselaer
+// SPDX-FileCopyrightText: 2022 Ye Jun Huang
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -26,6 +27,8 @@ sealed partial record WslDistributions
     public const string InstallWslUrl = "https://aka.ms/installwsl";
     public const string SetWslVersionUrl = "https://docs.microsoft.com/windows/wsl/basic-commands#set-wsl-version-to-1-or-2";
     public const string WslWikiUrl = "https://github.com/dorssel/usbipd-win/wiki/WSL-support";
+    public const string WslConfigFileName = ".wslconfig";
+    public const string VmSwitchSectionKey = "wsl2:vmSwitch";
 
     public static readonly string WslPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "wsl.exe");
 
@@ -51,22 +54,23 @@ sealed partial record WslDistributions
 
     public static string GetVMSwitchName()
     {
-        string vmSwitchName = "WSL";
-        string wslConfigFilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        string wslConfigFileName = ".wslconfig";
-        string vmSwitchSectionKey = "wsl2:vmSwitch";
+        var vmSwitchName = "WSL";
+        var wslConfigFilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-        var wslConfigFilePathName = Path.Join(wslConfigFilePath, wslConfigFileName);
+        var wslConfigFilePathName = Path.Join(wslConfigFilePath, WslConfigFileName);
         if (File.Exists(wslConfigFilePathName))
         {
             using var fileStream = File.OpenRead(wslConfigFilePathName);
             //using IConfigurationBuilder.AddIniFile() would throw compile error IL2026.
             //IL2026: Members attributed with RequiresUnreferencedCode may break when trimming.
             var dict = IniStreamConfigurationProvider.Read(fileStream);
-            string? vmSwitchConfigName;
-            if (dict.TryGetValue(vmSwitchSectionKey, out vmSwitchConfigName))
+            if (dict.TryGetValue(VmSwitchSectionKey, out var vmSwitchConfigName))
+            {
                 if (!string.IsNullOrWhiteSpace(vmSwitchConfigName))
+                {
                     vmSwitchName = vmSwitchConfigName;
+                }
+            }
         }
         return vmSwitchName;
     }


### PR DESCRIPTION
The new version win10 win11 22H2 supports wsl2 bridged mode.
Reference link https://github.com/microsoft/WSL/issues/4150 .
It changes the name of vmSwitch from the default "WSL" to a user-modifiable one.

Set in the SpecialFolder.UserProfile/.wslconfig file as follows:

[wsl2]
networkingMode=bridged
vmSwitch=usermodifiable