### PR TITLE
Fix auto-attach when running as a systemd service

### DIFF
--- a/Usbipd/wsl-scripts/auto-attach.sh
+++ b/Usbipd/wsl-scripts/auto-attach.sh
@@ -93,11 +93,13 @@ is_attached() {
     return 1
 }
 
-sleep() {
-    local SECONDS=$(($1))
+if [[ -t 0 ]]; then
     # sleep without creating a new process
-    read -r -t $SECONDS </proc/self/fd/1 || :
-}
+    sleep() {
+        local SECONDS=$(($1))
+        read -r -t $SECONDS || :
+    }
+fi
 
 while :; do
     if is_attached; then


### PR DESCRIPTION
When running this as a systemd service, I don't have permissions to access `/proc/self/fd/1`. However, during my trial and errors, you don't need this, but read will by default wait for stdin if called without a pipe.