### PR TITLE
Fix support for older WSL versions

### DIFF
--- a/Usbipd/Wsl.cs
+++ b/Usbipd/Wsl.cs
@@ -58,8 +58,6 @@ static partial class Wsl
             startInfo.ArgumentList.Add("root");
             startInfo.ArgumentList.Add("--cd");
             startInfo.ArgumentList.Add(linux.Value.directory);
-            startInfo.ArgumentList.Add("--shell-type");
-            startInfo.ArgumentList.Add("none");
             startInfo.ArgumentList.Add("--exec");
         }
         foreach (var argument in arguments)


### PR DESCRIPTION
- remove `--shell-type none` as it is redundant when using `--exec`

Fixes https://github.com/dorssel/usbipd-win/issues/861