### PR TITLE
Bump Microsoft.CodeAnalysis.CSharp from 4.8.0 to 4.9.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,7 @@ SPDX-License-Identifier: GPL-3.0-only
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <!-- UsbIds -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <!-- Usbipd.PowerShell -->
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
     <!-- Installer -->

--- a/UsbIds/UsbIds.csproj
+++ b/UsbIds/UsbIds.csproj
@@ -13,7 +13,6 @@ SPDX-License-Identifier: GPL-3.0-only
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
- remove unnecessary explicit Microsoft.CodeAnalysis.Analyzers reference