### PR TITLE
Fix Dependabot

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,7 @@ SPDX-License-Identifier: GPL-3.0-only
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' != 'true'">false</ContinuousIntegrationBuild>
 
     <!-- Use the latest .NET SDK -->
-    <!-- This product requires Windows 10 (Windows Server 2019) or higher -->
-    <MainTargetFramework>net9.0-windows10.0.17763</MainTargetFramework>
+    <MainTargetFramework>net9.0</MainTargetFramework>
     <!-- This product only supports x64 and arm64 (the only architectures supported by VBoxUsb) -->
     <Platforms>x64;ARM64</Platforms>
     <EnableDynamicPlatformResolution>true</EnableDynamicPlatformResolution>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,6 +17,13 @@ SPDX-License-Identifier: GPL-3.0-only
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\strongname.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- This product requires Windows 10 (Windows Server 2019) or higher. -->
+    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute" Condition="!$(TargetFramework.Contains('netstandard'))">
+      <_Parameter1>windows10.0.17763</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <Target Name="RemoveDebug" AfterTargets="Publish">
     <ItemGroup>
       <DebugFiles Include="$(PublishDir)\**\*.pdb" />

--- a/UnitTests/packages.lock.json
+++ b/UnitTests/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net9.0-windows10.0.17763": {
+    "net9.0": {
       "Dorssel.GitVersion.MsBuild": {
         "type": "Direct",
         "requested": "[1.1.1, )",

--- a/Usbipd.Automation/packages.lock.json
+++ b/Usbipd.Automation/packages.lock.json
@@ -23,7 +23,7 @@
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
       }
     },
-    "net9.0-windows10.0.17763": {
+    "net9.0": {
       "Dorssel.GitVersion.MsBuild": {
         "type": "Direct",
         "requested": "[1.1.1, )",

--- a/Usbipd/Properties/PublishProfiles/InputForInstaller_win-arm64.pubxml
+++ b/Usbipd/Properties/PublishProfiles/InputForInstaller_win-arm64.pubxml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-only
     <Platform>arm64</Platform>
     <PublishDir>bin\publish\arm64</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net9.0-windows10.0.17763</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/Usbipd/Properties/PublishProfiles/InputForInstaller_win-x64.pubxml
+++ b/Usbipd/Properties/PublishProfiles/InputForInstaller_win-x64.pubxml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-only
     <Platform>x64</Platform>
     <PublishDir>bin\publish\x64</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net9.0-windows10.0.17763</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/Usbipd/packages.lock.json
+++ b/Usbipd/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net9.0-windows10.0.17763": {
+    "net9.0": {
       "Dorssel.GitVersion.MsBuild": {
         "type": "Direct",
         "requested": "[1.1.1, )",
@@ -361,7 +361,7 @@
         "type": "Project"
       }
     },
-    "net9.0-windows10.0.17763/win-arm64": {
+    "net9.0/win-arm64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
         "requested": "[9.0.2, )",
@@ -390,7 +390,7 @@
         }
       }
     },
-    "net9.0-windows10.0.17763/win-x64": {
+    "net9.0/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
         "requested": "[9.0.2, )",


### PR DESCRIPTION
- Dependabot cannot handle composite TargetFramework
- also improves netstandard packages.lock