### PR TITLE
auto-attach: Report failure if bash is missing.

### DIFF
--- a/Usbipd/WSL/auto-attach.sh
+++ b/Usbipd/WSL/auto-attach.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # SPDX-FileCopyrightText: 2022 Frans van Dorsselaer
 #
@@ -8,6 +8,15 @@
 #    auto-attach.sh <HOST-IP-ADDRESS> <BUSID>
 
 set -e
+
+if [ -z "$BASH" ]; then
+  # Bash is required later in this script, check and report if it's not available
+  which bash > /dev/null || { echo "--auto-attach is not available without bash shell"; exit 1; }
+
+  # Relaunch this script with bash as a separate background process.
+  bash ${0} ${@} & disown
+  exit 0
+fi
 
 HOST=$1
 BUSID=$2

--- a/Usbipd/Wsl.cs
+++ b/Usbipd/Wsl.cs
@@ -584,11 +584,14 @@ static partial class Wsl
         {
             console.ReportInfo("Starting endless attach loop; press Ctrl+C to quit.");
 
-            _ = await RunWslAsync((distribution, WslMountPoint), FilterUsbip, false, cancellationToken, "./auto-attach.sh", hostAddress.ToString(),
+            var wslResult = await RunWslAsync((distribution, WslMountPoint), FilterUsbip, false, cancellationToken, "/bin/sh", "./auto-attach.sh", hostAddress.ToString(),
                 busId.ToString());
-            // This process always ends in failure, as it is supposed to run an endless loop.
-            // This may be intended by the user (Ctrl+C, WSL shutdown), others may be real errors.
-            // There is no way to tell the difference...
+            
+            if (wslResult.ExitCode != 0)
+            {
+                console.ReportError(wslResult.stdout);
+                return ExitCode.Failure;
+            }
         }
 
         return ExitCode.Success;


### PR DESCRIPTION
Based on https://github.com/dorssel/usbipd-win/issues/1176 auto-attach is expected to fail if bash is not available, eg, in docker-desktop distro. The error message shown however does not indicate this function as the source of the failure however.

This PR launches the auto-attach script in /bin/sh instead before checking / reporting on bash missing, then re-launches itself with bash in the background.

TODO: This PR has not been tested sorry, I'm not set up to compile [usbipd-win](https://github.com/dorssel/usbipd-win) but wanted to push this idea as a suggestion.