### PR TITLE
Use shell-type login for RunWslAsync

### DIFF
--- a/Usbipd/Wsl.cs
+++ b/Usbipd/Wsl.cs
@@ -101,12 +101,18 @@ static partial class Wsl
             startInfo.ArgumentList.Add("root");
             startInfo.ArgumentList.Add("--cd");
             startInfo.ArgumentList.Add(linux.Value.directory);
-            startInfo.ArgumentList.Add("--shell-type");
-            startInfo.ArgumentList.Add("login");
+            startInfo.ArgumentList.Add("--exec");
+            startInfo.ArgumentList.Add("/usr/bin/env");
+            startInfo.ArgumentList.Add("sh");
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add($"{string.Join(" ", arguments)}");
         }
-        foreach (var argument in arguments)
+        else
         {
-            startInfo.ArgumentList.Add(argument);
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
         }
 
         using var process = Process.Start(startInfo)
@@ -359,7 +365,7 @@ static partial class Wsl
         // NOTE: We don't know the shell type (for example, docker-desktop does not even have bash),
         //       so be as portable as possible: single line, use 'test', quote all paths, etc.
         {
-            var wslResult = await RunWslAsync((distribution, "/"), null, false, cancellationToken, "/bin/sh", "-c", $$"""
+            var wslResult = await RunWslAsync((distribution, "/"), null, false, cancellationToken, $$"""
                 if ! test -d "{{WslMountPoint}}"; then
                     mkdir -m 0000 "{{WslMountPoint}}";
                 fi;

--- a/Usbipd/Wsl.cs
+++ b/Usbipd/Wsl.cs
@@ -1,6 +1,7 @@
 ﻿// SPDX-FileCopyrightText: Microsoft Corporation
 // SPDX-FileCopyrightText: 2021 Frans van Dorsselaer
 // SPDX-FileCopyrightText: 2022 Ye Jun Huang
+// SPDX-FileContributor: Fred Frey
 //
 // SPDX-License-Identifier: GPL-3.0-only
 


### PR DESCRIPTION
Resolves #1219 

Using the `--shell-type login` instead of `--exec` allows us to honor root's `$PATH`.

Also warn the user if `modprobe` isn't found, they may not need to update their WSL.