### PR TITLE
Adding Bus reported device description

### DIFF
--- a/Usbipd/NativeMethods.txt
+++ b/Usbipd/NativeMethods.txt
@@ -53,6 +53,7 @@ SetupDiSetDeviceInstallParams
 
 FILE_SKIP_COMPLETION_PORT_ON_SUCCESS
 
+DEVPKEY_Device_BusReportedDeviceDesc
 DEVPKEY_Device_Children
 DEVPKEY_Device_CompatibleIds
 DEVPKEY_Device_DevNodeStatus

--- a/Usbipd/WindowsDevice.cs
+++ b/Usbipd/WindowsDevice.cs
@@ -154,6 +154,15 @@ sealed partial class WindowsDevice : IEquatable<WindowsDevice>
                 AddDescription(friendlyName);
             }
 
+            // The BusReportedDeviceDesc is very useful for USB\COMPOSITE, as it often contains the
+            // USB string table description of the device, which is more specific than the FriendlyName.
+            // For example, it can distinguish between different types of HID devices,
+            // whereas the FriendlyName is often just "HID Device" for all of them.
+            if (TryGetProperty(Node, PInvoke.DEVPKEY_Device_BusReportedDeviceDesc, out string description))
+            {
+                AddDescription(description);
+            }
+
             foreach (var childDevice in Children)
             {
                 // NAME is FriendlyName (if it exists), or else it is Description (if it exists).


### PR DESCRIPTION
Hi,
Recently, I was using this tool on some composite devices and found that when multiple composite devices are present in the system, it's hard to determine which one needs to be attached. Therefore, I added this new "Bus reported description" to indicate which device this is.

Thanks